### PR TITLE
Initialize project architecture files | #2

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,23 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/app/src/main/java/com/dodo/flashcards/architecture/BaseRoutingViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/architecture/BaseRoutingViewModel.kt
@@ -1,0 +1,18 @@
+package com.dodo.flashcards.architecture
+
+abstract class BaseRoutingViewModel<
+        TypeOfViewState : ViewState,
+        TypeOfViewEvent : ViewEvent,
+        TypeOfDestination : Destination>
+    : BaseViewModel<TypeOfViewState, TypeOfViewEvent>() {
+
+    private var router: Router<TypeOfDestination>? = null
+
+    fun attachRouter(router: Router<TypeOfDestination>) {
+        this.router = router
+        onRouterAttached()
+    }
+
+    /** Optional in implementing ViewModel **/
+    open fun onRouterAttached() {}
+}

--- a/app/src/main/java/com/dodo/flashcards/architecture/BaseViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/architecture/BaseViewModel.kt
@@ -1,0 +1,40 @@
+package com.dodo.flashcards.architecture
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+abstract class BaseViewModel<TypeOfViewState : ViewState, TypeOfViewEvent : ViewEvent> :
+    ViewModel(), EventReceiver<TypeOfViewEvent>, StatePusher<TypeOfViewState> {
+
+    companion object {
+        /** Minimum duration between two debounced events in milliseconds **/
+        private const val DEBOUNCE_TIME_MS = 1000L
+    }
+
+    private var lastDebouncedTime: Long = Long.MIN_VALUE
+
+    /** Utility for implementing [ViewModel] **/
+    private val lastPushedState: TypeOfViewState?
+        get() = viewState.value
+
+    /** Private mutable and public immutable [ViewState] **/
+    private var _viewState: MutableStateFlow<TypeOfViewState?> = MutableStateFlow(null)
+    final override val viewState: StateFlow<TypeOfViewState?> = _viewState
+
+    final override fun onEventDebounced(event: TypeOfViewEvent) {
+        val currTime = System.currentTimeMillis()
+        if (currTime > lastDebouncedTime + DEBOUNCE_TIME_MS) {
+            lastDebouncedTime = currTime
+            onEvent(event)
+        }
+    }
+
+    final override fun TypeOfViewState.push() {
+        pushState(this)
+    }
+
+    final override fun pushState(state: TypeOfViewState) {
+        _viewState.value = state
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/architecture/EventReceiver.kt
+++ b/app/src/main/java/com/dodo/flashcards/architecture/EventReceiver.kt
@@ -1,0 +1,15 @@
+package com.dodo.flashcards.architecture
+
+import androidx.lifecycle.ViewModel
+
+interface ViewEvent
+
+interface EventReceiver<TypeOfViewEvent : ViewEvent> {
+    /** Invoked by the View and received by the implementing [ViewModel] **/
+    fun onEvent(event: TypeOfViewEvent)
+
+    /** Not all [ViewEvent] should occur more than once when rapidly clicked,
+     * this utility method will restrict frequency of sent [ViewEvent] according to
+     * an implementation-determined debounce time. */
+    fun onEventDebounced(event: TypeOfViewEvent)
+}

--- a/app/src/main/java/com/dodo/flashcards/architecture/Router.kt
+++ b/app/src/main/java/com/dodo/flashcards/architecture/Router.kt
@@ -1,0 +1,7 @@
+package com.dodo.flashcards.architecture
+
+interface Destination
+
+interface Router<TypeOfDestination: Destination> {
+    fun routeTo(destination: TypeOfDestination)
+}

--- a/app/src/main/java/com/dodo/flashcards/architecture/StatePusher.kt
+++ b/app/src/main/java/com/dodo/flashcards/architecture/StatePusher.kt
@@ -1,0 +1,19 @@
+package com.dodo.flashcards.architecture
+
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import androidx.lifecycle.ViewModel
+
+interface ViewState
+
+interface StatePusher<TypeOfViewState : ViewState> {
+    /** State flow observed in View, triggers recomposition on each pushed [ViewState] **/
+    val viewState: StateFlow<TypeOfViewState?>
+
+    /** Abstraction to update underlying [MutableStateFlow] instance of [viewState]
+     * from the implementing ViewModel **/
+    fun pushState(state: TypeOfViewState)
+
+    /** Optional extension to push a [ViewState] in the implementing [ViewModel] scope **/
+    fun TypeOfViewState.push()
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.dodo.flashcards
+package com.dodo.flashcards.presentation
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -10,7 +10,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.dodo.flashcards.ui.theme.FlashcardsAppTheme
+import com.dodo.flashcards.presentation.theme.FlashcardsAppTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/dodo/flashcards/presentation/theme/Color.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.dodo.flashcards.ui.theme
+package com.dodo.flashcards.presentation.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/com/dodo/flashcards/presentation/theme/Shape.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/theme/Shape.kt
@@ -1,4 +1,4 @@
-package com.dodo.flashcards.ui.theme
+package com.dodo.flashcards.presentation.theme
 
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Shapes

--- a/app/src/main/java/com/dodo/flashcards/presentation/theme/Theme.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/theme/Theme.kt
@@ -1,4 +1,4 @@
-package com.dodo.flashcards.ui.theme
+package com.dodo.flashcards.presentation.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme

--- a/app/src/main/java/com/dodo/flashcards/presentation/theme/Type.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.dodo.flashcards.ui.theme
+package com.dodo.flashcards.presentation.theme
 
 import androidx.compose.material.Typography
 import androidx.compose.ui.text.TextStyle


### PR DESCRIPTION
**Background:**
To start work our architecture must be defined. We will utilize interfaces to reinforce the `BaseViewModel` as a single-source-of-truth (SST) for all `ViewState` by defining a single `StateFlow` which Views will observe. The View will communicate with the `BaseViewModel` only through `onEvent` methods defined in the `EventReceiver` interface and the View should never contain logic itself. To communicate with the navigation graph, an implementation of `BaseViewModel`, `BaseRoutingViewModel` is defined, which may invoke `routeTo` on its attached `Router` instance.

**Changes:**
* Create `architecture` package, define all expected interfaces and abstract classes needed with comments.
* Create `presentation` package, move `MainActivity` and `ui.theme` inside.

**Architecture Diagram:**
![image](https://user-images.githubusercontent.com/77797048/193419442-43934d42-2861-4463-a92d-c4efaa522e7a.png)

Closes #2 