### PR TITLE
Add Dagger & Navigation Dependencies | #40

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,10 +1,14 @@
 plugins {
     id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
+    id 'kotlin-android'
+    id 'kotlin-kapt'
+    id 'dagger.hilt.android.plugin'
+    // Navigation library
+    id 'com.google.devtools.ksp' version '1.6.10-1.0.2'
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.dodo.flashcards"
@@ -36,7 +40,8 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion compose_version
+        kotlinCompilerExtensionVersion '1.3.1'
+        kotlinCompilerVersion compose_version
     }
     packagingOptions {
         resources {
@@ -46,17 +51,63 @@ android {
 }
 
 dependencies {
+    // Retrofit
+    // https://github.com/square/retrofitokhttp3
+    // https://github.com/square/okhttp
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.3'
 
-    implementation 'androidx.core:core-ktx:1.7.0'
+    // Datastore
+    // https://developer.android.com/codelabs/android-preferences-datastore#4
+    implementation "androidx.datastore:datastore-preferences:1.0.0"
+    implementation "androidx.datastore:datastore:1.0.0"
+    implementation "androidx.datastore:datastore-rxjava2:1.0.0"
+    implementation "androidx.datastore:datastore-rxjava3:1.0.0"
+
+    // ROOM
+    implementation 'androidx.room:room-runtime:2.4.3'
+    kapt 'androidx.room:room-compiler:2.4.3'
+    implementation 'androidx.room:room-ktx:2.4.3'
+
+    // ICONS
+    implementation "androidx.compose.material:material-icons-extended:$compose_version"
+
+    // Coroutines
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
+
+    // Coroutine Lifecycle Scopes
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
+
+    // Dagger-Hilt
+    implementation 'com.google.dagger:hilt-android:2.43.2'
+    implementation 'com.google.android.gms:play-services-maps:18.1.0'
+    kapt 'com.google.dagger:hilt-android-compiler:2.43.2'
+    kapt 'androidx.hilt:hilt-compiler:1.0.0'
+    implementation 'androidx.hilt:hilt-navigation-compose:1.0.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-savedstate:2.5.1'
+
+    // Navigation
+    implementation("androidx.navigation:navigation-compose:2.5.2")
+
+    // Navigation Animated Library
+    // This is important to avoid the goofy awkward look of the top bar fading in and out
+    implementation "com.google.accompanist:accompanist-navigation-animation:0.22.1-rc"
+
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'com.google.android.material:material:1.6.1'
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.3.1'
-    testImplementation 'junit:junit:4.13.2'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
+    implementation 'androidx.activity:activity-compose:1.6.0'
+    testImplementation 'junit:junit:+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,23 +4,17 @@
     package="com.dodo.flashcards">
 
     <application
-        android:allowBackup="true"
-        android:dataExtractionRules="@xml/data_extraction_rules"
-        android:fullBackupContent="@xml/backup_rules"
+        android:name=".FlashcardsApplication"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
         android:theme="@style/Theme.FlashcardsApp"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
+            android:name=".presentation.MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.FlashcardsApp">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/dodo/flashcards/FlashcardsApplication.kt
+++ b/app/src/main/java/com/dodo/flashcards/FlashcardsApplication.kt
@@ -1,0 +1,7 @@
+package com.dodo.flashcards
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class FlashcardsApplication : Application()

--- a/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
@@ -11,7 +11,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.dodo.flashcards.presentation.theme.FlashcardsAppTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,20 @@
 buildscript {
     ext {
-        compose_version = '1.1.0-beta01'
+        kotlin_version = '1.7.10'
+        compose_version = '1.2.1'
     }
-}// Top-level build file where you can add configuration options common to all sub-projects/modules.
-plugins {
-    id 'com.android.application' version '7.2.0' apply false
-    id 'com.android.library' version '7.2.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.5.31' apply false
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath('com.google.dagger:hilt-android-gradle-plugin:2.43.2')
+        classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
**Background:**

To use HiltViewModel and dependency injection we need to add Dagger Hilt dependencies. There are also some other dependencies we need like those in navigation libraries.

**Changes:**

This commit adds Dagger Hilt dependencies (including some other dependencies) and defines `MainActivity` as the AndroidEntryPoint.

**Testing:**

Make sure you can still build and launch the app.

Closes #40