### PR TITLE
Stub out authorization screens | #3 #6 #4

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/presentation/MainModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainModels.kt
@@ -1,0 +1,7 @@
+package com.dodo.flashcards.presentation
+
+import com.dodo.flashcards.architecture.Destination
+
+sealed interface MainDestination : Destination {
+
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/login_screen/LoginScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/login_screen/LoginScreen.kt
@@ -1,0 +1,11 @@
+package com.dodo.flashcards.presentation.login_screen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+
+@Composable
+fun LoginScreen(viewModel: LoginScreenViewModel) {
+    viewModel.viewState.collectAsState().value?.apply {
+
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/login_screen/LoginScreenModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/login_screen/LoginScreenModels.kt
@@ -1,0 +1,17 @@
+package com.dodo.flashcards.presentation.login_screen
+
+import com.dodo.flashcards.architecture.ViewEvent
+import com.dodo.flashcards.architecture.ViewState
+
+sealed interface LoginScreenViewEvent : ViewEvent {
+    object ClickedForgotPassword : LoginScreenViewEvent
+    object ClickedLogin : LoginScreenViewEvent
+    object ClickedRegister : LoginScreenViewEvent
+    data class TextEmailChanged(val changedTo: String) : LoginScreenViewEvent
+    data class TextPassChanged(val changedTo: String) : LoginScreenViewEvent
+}
+
+data class LoginScreenViewState(
+    val textEmail: String,
+    val textPass: String
+) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/login_screen/LoginScreenViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/login_screen/LoginScreenViewModel.kt
@@ -1,0 +1,44 @@
+package com.dodo.flashcards.presentation.login_screen
+
+import androidx.lifecycle.SavedStateHandle
+import com.dodo.flashcards.architecture.BaseRoutingViewModel
+import com.dodo.flashcards.presentation.MainDestination
+import com.dodo.flashcards.presentation.login_screen.LoginScreenViewEvent.*
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginScreenViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : BaseRoutingViewModel<LoginScreenViewState, LoginScreenViewEvent, MainDestination>() {
+
+    override fun onEvent(event: LoginScreenViewEvent) {
+        when (event) {
+            is ClickedForgotPassword -> onClickedForgotPassword()
+            is ClickedLogin -> onClickedLogin()
+            is ClickedRegister -> onClickedRegister()
+            is TextEmailChanged -> onTextEmailChanged(event)
+            is TextPassChanged -> onTextPassChanged(event)
+        }
+    }
+
+    private fun onClickedForgotPassword() {
+
+    }
+
+    private fun onClickedLogin() {
+
+    }
+
+    private fun onClickedRegister() {
+
+    }
+
+    private fun onTextEmailChanged(event: TextEmailChanged) {
+
+    }
+
+    private fun onTextPassChanged(event: TextPassChanged) {
+
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/register_screen/RegisterScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/register_screen/RegisterScreen.kt
@@ -1,0 +1,11 @@
+package com.dodo.flashcards.presentation.register_screen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+
+@Composable
+fun RegisterScreen(viewModel: RegisterScreenViewModel) {
+    viewModel.viewState.collectAsState().value?.apply {
+
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/register_screen/RegisterScreenModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/register_screen/RegisterScreenModels.kt
@@ -1,0 +1,16 @@
+package com.dodo.flashcards.presentation.register_screen
+
+import com.dodo.flashcards.architecture.ViewEvent
+import com.dodo.flashcards.architecture.ViewState
+
+sealed interface RegisterScreenViewEvent : ViewEvent {
+    object ClickedRegister : RegisterScreenViewEvent
+    data class TextEmailChanged(val changedTo: String) : RegisterScreenViewEvent
+    data class TextPassChanged(val changedTo: String) : RegisterScreenViewEvent
+    // Todo, add remaining text change events when we finalize what info we will collect
+}
+
+data class RegisterScreenViewState(
+    val textEmail: String,
+    val textPass: String
+) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/register_screen/RegisterScreenViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/register_screen/RegisterScreenViewModel.kt
@@ -1,0 +1,34 @@
+package com.dodo.flashcards.presentation.register_screen
+
+import androidx.lifecycle.SavedStateHandle
+import com.dodo.flashcards.architecture.BaseRoutingViewModel
+import com.dodo.flashcards.presentation.MainDestination
+import com.dodo.flashcards.presentation.register_screen.RegisterScreenViewEvent.*
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class RegisterScreenViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : BaseRoutingViewModel<RegisterScreenViewState, RegisterScreenViewEvent, MainDestination>() {
+
+    override fun onEvent(event: RegisterScreenViewEvent) {
+        when (event) {
+            is ClickedRegister -> onClickedRegister()
+            is TextEmailChanged -> onTextEmailChanged(event)
+            is TextPassChanged -> onTextPassChanged(event)
+        }
+    }
+
+    private fun onClickedRegister() {
+
+    }
+
+    private fun onTextEmailChanged(event: TextEmailChanged) {
+
+    }
+
+    private fun onTextPassChanged(event: TextPassChanged) {
+
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcome_screen/WelcomeScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcome_screen/WelcomeScreen.kt
@@ -1,0 +1,11 @@
+package com.dodo.flashcards.presentation.welcome_screen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+
+@Composable
+fun WelcomeScreen(viewModel: WelcomeScreenViewModel) {
+    viewModel.viewState.collectAsState().value?.apply {
+
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcome_screen/WelcomeScreenModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcome_screen/WelcomeScreenModels.kt
@@ -1,0 +1,12 @@
+package com.dodo.flashcards.presentation.welcome_screen
+
+import com.dodo.flashcards.architecture.ViewEvent
+import com.dodo.flashcards.architecture.ViewState
+
+sealed interface WelcomeScreenViewEvent : ViewEvent {
+    object ClickedLogout : WelcomeScreenViewEvent
+}
+
+data class WelcomeScreenViewState(
+    val displayName: String
+) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcome_screen/WelcomeScreenViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcome_screen/WelcomeScreenViewModel.kt
@@ -1,0 +1,25 @@
+package com.dodo.flashcards.presentation.welcome_screen
+
+import androidx.lifecycle.SavedStateHandle
+import com.dodo.flashcards.architecture.BaseRoutingViewModel
+import com.dodo.flashcards.presentation.MainDestination
+import com.dodo.flashcards.presentation.welcome_screen.WelcomeScreenViewEvent.ClickedLogout
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+
+@HiltViewModel
+class WelcomeScreenViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : BaseRoutingViewModel<WelcomeScreenViewState, WelcomeScreenViewEvent, MainDestination>() {
+
+    override fun onEvent(event: WelcomeScreenViewEvent) {
+        when (event) {
+            is ClickedLogout -> onClickedLogout()
+        }
+    }
+
+    private fun onClickedLogout() {
+
+    }
+}


### PR DESCRIPTION
**Background:**

For our first sprint, our goal is to complete all login / registration / welcome user flow. This will include: logging in an existing account, registering a new account, retrieving a forgotten password, and being welcomed once logged in (with the option to log-out).

**Changes:**

Stub out ViewEvents, ViewStates, ViewModels, and Composables for `login_screen`, `register_screen`, and `welcome_screen`.

Screens are not accessible currently.

Closes #3
Closes #4
Closes #6 