### PR TITLE
Crude implementation of registration | #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+app/google-services.json

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'kotlin-android'
     id 'kotlin-kapt'
     id 'dagger.hilt.android.plugin'
+    id 'com.google.gms.google-services'
     // Navigation library
     id 'com.google.devtools.ksp' version '1.6.10-1.0.2'
 }
@@ -51,6 +52,11 @@ android {
 }
 
 dependencies {
+    // Firebase
+    implementation 'com.google.firebase:firebase-bom:30.5.0'
+    implementation 'com.google.firebase:firebase-auth-ktx:21.0.8'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.1'
+
     // Retrofit
     // https://github.com/square/retrofitokhttp3
     // https://github.com/square/okhttp

--- a/app/src/main/java/com/dodo/flashcards/architecture/BaseViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/architecture/BaseViewModel.kt
@@ -15,7 +15,7 @@ abstract class BaseViewModel<TypeOfViewState : ViewState, TypeOfViewEvent : View
     private var lastDebouncedTime: Long = Long.MIN_VALUE
 
     /** Utility for implementing [ViewModel] **/
-    private val lastPushedState: TypeOfViewState?
+    val lastPushedState: TypeOfViewState?
         get() = viewState.value
 
     /** Private mutable and public immutable [ViewState] **/

--- a/app/src/main/java/com/dodo/flashcards/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/dodo/flashcards/data/repository/AuthRepositoryImpl.kt
@@ -1,0 +1,42 @@
+package com.dodo.flashcards.data.repository
+
+import com.dodo.flashcards.domain.models.AuthRepository
+import com.dodo.flashcards.util.Resource
+import com.dodo.flashcards.util.Resource.*
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import kotlinx.coroutines.tasks.await
+import java.util.concurrent.CancellationException
+import javax.inject.Inject
+
+class AuthRepositoryImpl @Inject constructor(private val auth: FirebaseAuth) : AuthRepository {
+
+    override suspend fun getCurrentUser(): FirebaseUser? = auth.currentUser
+
+    override suspend fun registerUser(
+        email: String,
+        password: String
+    ): Resource<FirebaseUser> {
+        return try {
+            val response = auth.createUserWithEmailAndPassword(email, password).await().user!!
+            Success(response)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Error(exception = e)
+        }
+    }
+
+    override suspend fun login(email: String, password: String): Resource<FirebaseUser> {
+        return try {
+            val response = auth.signInWithEmailAndPassword(email, password).await().user!!
+            Success(response)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Error(exception = e)
+        }
+    }
+
+    override suspend fun logout() {
+        auth.signOut()
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/di/AppModule.kt
+++ b/app/src/main/java/com/dodo/flashcards/di/AppModule.kt
@@ -1,0 +1,23 @@
+package com.dodo.flashcards.di
+
+import com.dodo.flashcards.data.repository.AuthRepositoryImpl
+import com.dodo.flashcards.domain.models.AuthRepository
+import com.google.firebase.auth.FirebaseAuth
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+    @Singleton
+    @Provides
+    fun provideAuth(): FirebaseAuth = FirebaseAuth.getInstance()
+
+    @Provides
+    fun provideAuthRepository(
+        firebaseAuth: FirebaseAuth
+    ): AuthRepository = AuthRepositoryImpl(firebaseAuth)
+}

--- a/app/src/main/java/com/dodo/flashcards/domain/models/AuthRepository.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/models/AuthRepository.kt
@@ -1,0 +1,20 @@
+package com.dodo.flashcards.domain.models
+
+import com.dodo.flashcards.util.Resource
+import com.google.firebase.auth.FirebaseUser
+
+interface AuthRepository {
+    suspend fun getCurrentUser(): FirebaseUser?
+
+    suspend fun registerUser(
+        email: String,
+        password: String
+    ): Resource<FirebaseUser>
+
+    suspend fun login(
+        email: String,
+        password: String
+    ): Resource<FirebaseUser>
+
+    suspend fun logout()
+}

--- a/app/src/main/java/com/dodo/flashcards/domain/usecases/RegisterUserUseCase.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/usecases/RegisterUserUseCase.kt
@@ -1,0 +1,15 @@
+package com.dodo.flashcards.domain.usecases
+
+import com.dodo.flashcards.domain.models.AuthRepository
+import com.dodo.flashcards.util.Resource
+import com.google.firebase.auth.FirebaseUser
+import javax.inject.Inject
+
+class RegisterUserUseCase @Inject constructor(private val authRepository: AuthRepository) {
+    suspend operator fun invoke(
+        email: String,
+        password: String
+    ): Resource<FirebaseUser> {
+        return authRepository.registerUser(email, password)
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
@@ -10,6 +10,8 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.dodo.flashcards.presentation.register_screen.RegisterScreen
 import com.dodo.flashcards.presentation.theme.FlashcardsAppTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -24,7 +26,9 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colors.background
                 ) {
-                    Greeting("Android")
+                    // Todo, we need to define router and move this to the NavHost
+                    // This is temporary to test registration
+                    RegisterScreen(viewModel = hiltViewModel())
                 }
             }
         }

--- a/app/src/main/java/com/dodo/flashcards/presentation/register_screen/RegisterScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/register_screen/RegisterScreen.kt
@@ -1,11 +1,47 @@
 package com.dodo.flashcards.presentation.register_screen
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import com.dodo.flashcards.R
+import com.dodo.flashcards.presentation.register_screen.RegisterScreenViewEvent.*
 
 @Composable
 fun RegisterScreen(viewModel: RegisterScreenViewModel) {
     viewModel.viewState.collectAsState().value?.apply {
-
+        // Todo, clean up UI
+        Column {
+            TextField(
+                value = textEmail,
+                onValueChange = {
+                    viewModel.onEvent(TextEmailChanged(changedTo = it))
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Email
+                )
+            )
+            TextField(
+                value = textPass,
+                onValueChange = {
+                    viewModel.onEvent(TextPassChanged(changedTo = it))
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password
+                )
+            )
+            Button(
+                onClick = {
+                    viewModel.onEvent(ClickedRegister)
+                }
+            ) {
+                Text(text = stringResource(R.string.register_register_button))
+            }
+        }
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/register_screen/RegisterScreenViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/register_screen/RegisterScreenViewModel.kt
@@ -1,16 +1,28 @@
 package com.dodo.flashcards.presentation.register_screen
 
-import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import com.dodo.flashcards.architecture.BaseRoutingViewModel
+import com.dodo.flashcards.domain.usecases.RegisterUserUseCase
 import com.dodo.flashcards.presentation.MainDestination
 import com.dodo.flashcards.presentation.register_screen.RegisterScreenViewEvent.*
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class RegisterScreenViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    private val registerUserUseCase: RegisterUserUseCase
 ) : BaseRoutingViewModel<RegisterScreenViewState, RegisterScreenViewEvent, MainDestination>() {
+
+    init {
+        pushState(
+            RegisterScreenViewState(
+                textEmail = String(),
+                textPass = String()
+            )
+        )
+    }
 
     override fun onEvent(event: RegisterScreenViewEvent) {
         when (event) {
@@ -21,14 +33,32 @@ class RegisterScreenViewModel @Inject constructor(
     }
 
     private fun onClickedRegister() {
-
+        withLastState {
+            viewModelScope.launch(Dispatchers.IO) {
+                registerUserUseCase(textEmail, textPass)
+                    .doOnSuccess {
+                        // Todo: Route to LoginScreen
+                    }
+                    .doOnError {
+                        // Todo: Send error ViewState
+                    }
+            }
+        }
     }
 
     private fun onTextEmailChanged(event: TextEmailChanged) {
-
+        withLastState {
+            copy(textEmail = event.changedTo).push()
+        }
     }
 
     private fun onTextPassChanged(event: TextPassChanged) {
+        withLastState {
+            copy(textPass = event.changedTo).push()
+        }
+    }
 
+    private inline fun withLastState(block: RegisterScreenViewState.() -> Unit) {
+        lastPushedState?.run(block)
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/util/Resource.kt
+++ b/app/src/main/java/com/dodo/flashcards/util/Resource.kt
@@ -1,0 +1,37 @@
+package com.dodo.flashcards.util
+
+/**
+ * Wrapper class around a [TypeOfData] which is used when that data is retrieved
+ * from a repository which may either be successful, [Success], or error, [Error].
+ */
+sealed class Resource<TypeOfData>(open val data: TypeOfData? = null) {
+
+    data class Success<TypeOfData>(override val data: TypeOfData) : Resource<TypeOfData>(data)
+    data class Error<TypeOfData>(
+        override val data: TypeOfData? = null,
+        val exception: Exception? = null,
+        val message: String? = null
+    ) : Resource<TypeOfData>(data)
+
+    /**
+     * Callback invoked if this [Resource] is an instance of [Success].
+     * @return The calling [Resource].
+     */
+    inline fun doOnSuccess(
+        callback: Success<TypeOfData>.() -> Unit
+    ): Resource<TypeOfData> {
+        if (this is Success) callback(this)
+        return this
+    }
+
+    /**
+     * Callback invoked if this [Resource] is an instance of [Error].
+     * @return The calling [Resource].
+     */
+    inline fun doOnError(
+        callback: Error<TypeOfData>.() -> Unit
+    ): Resource<TypeOfData> {
+        if (this is Error) callback(this)
+        return this
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">FlashcardsApp</string>
+    <!-- Text shown on button which will register a user -->
+    <string name="register_register_button">Register</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
+        classpath 'com.google.gms:google-services:4.3.14'
         classpath 'com.android.tools.build:gradle:7.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath('com.google.dagger:hilt-android-gradle-plugin:2.43.2')


### PR DESCRIPTION
**Background:**

Web has merged a pull request which brings registration into their app, this commit brings the Android App to the same functionality.

**Changes:**

* Define `Resource` utility file
* Create crude `RegisterScreen` UI and send events from the UI to the ViewModel to be handled
* Define `AuthRepository` and implement the interface and a means to access it via. `RegisterUserUseCase`.

**Testing:**

Add `google-services.json` to your app folder, it contains Firebase key information and may be downloaded from our Discord. Run the app, enter a email and password and click Register. There is not currently any UI feedback. Open Firebase authentication console, you should see a new entry.