### PR TITLE
Add crude login funct, connect login / register / welcome | #11 #8  #38 #5

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/architecture/BaseRoutingViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/architecture/BaseRoutingViewModel.kt
@@ -13,6 +13,10 @@ abstract class BaseRoutingViewModel<
         onRouterAttached()
     }
 
+    fun routeTo(destination: TypeOfDestination) {
+        this.router?.routeTo(destination)
+    }
+
     /** Optional in implementing ViewModel **/
     open fun onRouterAttached() {}
 }

--- a/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/GetUserUseCase.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/GetUserUseCase.kt
@@ -1,0 +1,4 @@
+package com.dodo.flashcards.domain.usecases.authentication
+
+class GetUserUseCase {
+}

--- a/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/LoginUserUseCase.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/LoginUserUseCase.kt
@@ -1,15 +1,15 @@
-package com.dodo.flashcards.domain.usecases
+package com.dodo.flashcards.domain.usecases.authentication
 
 import com.dodo.flashcards.domain.models.AuthRepository
 import com.dodo.flashcards.util.Resource
 import com.google.firebase.auth.FirebaseUser
 import javax.inject.Inject
 
-class RegisterUserUseCase @Inject constructor(private val authRepository: AuthRepository) {
+class LoginUserUseCase @Inject constructor(private val authRepository: AuthRepository) {
     suspend operator fun invoke(
         email: String,
         password: String
     ): Resource<FirebaseUser> {
-        return authRepository.registerUser(email, password)
+        return authRepository.login(email, password)
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/LogoutUserUseCase.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/LogoutUserUseCase.kt
@@ -1,0 +1,11 @@
+package com.dodo.flashcards.domain.usecases.authentication
+
+import com.dodo.flashcards.domain.models.AuthRepository
+import javax.inject.Inject
+
+
+class LogoutUserUseCase @Inject constructor(private val authRepository: AuthRepository) {
+    suspend operator fun invoke() {
+        authRepository.logout()
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/RegisterUserUseCase.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/RegisterUserUseCase.kt
@@ -1,0 +1,15 @@
+package com.dodo.flashcards.domain.usecases.authentication
+
+import com.dodo.flashcards.domain.models.AuthRepository
+import com.dodo.flashcards.util.Resource
+import com.google.firebase.auth.FirebaseUser
+import javax.inject.Inject
+
+class RegisterUserUseCase @Inject constructor(private val authRepository: AuthRepository) {
+    suspend operator fun invoke(
+        email: String,
+        password: String
+    ): Resource<FirebaseUser> {
+        return authRepository.registerUser(email, password)
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
@@ -42,19 +42,41 @@ class MainActivity : ComponentActivity(), Router<MainDestination> {
     override fun routeTo(destination: MainDestination) {
         when (destination) {
             is NavigateLogin -> navigateLogin()
+            is NavigateRegister -> navigateRegister()
             is NavigateUp -> navigateUp()
+            is NavigateWelcome -> navigateWelcome()
         }
     }
 
     private fun navigateLogin() {
         navController.navigate(route = Login.route) {
-            popUpTo(route = Welcome.route) {
-                inclusive = true
+            if (navController.currentDestination?.route == Welcome.route) {
+                popUpTo(route = Welcome.route) {
+                    inclusive = true
+                }
             }
         }
     }
 
+    private fun navigateRegister() {
+        navController.navigate(route = Register.route)
+    }
+
     private fun navigateUp() {
         navController.navigateUp()
+    }
+
+    // Todo, evaluate cleaner way to do this; if this isn't done you can
+    // have a bug where you login --> register --> welcome --(logout)--> login, and
+    // still have the original login in the backstack.
+    private fun navigateWelcome() {
+        navController.navigate(route = Welcome.route) {
+            popUpTo(route = Register.route) {
+                inclusive = true
+            }
+            popUpTo(route = Login.route) {
+                inclusive = true
+            }
+        }
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/MainModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainModels.kt
@@ -15,5 +15,7 @@ sealed interface MainViewEvent : ViewEvent {
 
 sealed interface MainDestination : Destination {
     object NavigateLogin : MainDestination
+    object NavigateRegister : MainDestination
     object NavigateUp : MainDestination
+    object NavigateWelcome : MainDestination
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreen.kt
@@ -1,15 +1,69 @@
 package com.dodo.flashcards.presentation.loginScreen
 
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import com.dodo.flashcards.R
+import com.dodo.flashcards.presentation.loginScreen.LoginScreenViewEvent.*
 
 @Composable
 fun LoginScreen(viewModel: LoginScreenViewModel) {
-    // Todo remove placeholder
-    Text("Login placeholder")
-
     viewModel.viewState.collectAsState().value?.apply {
-
+        // Todo, clean up UI
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(text = stringResource(id = R.string.app_name))
+            TextField(
+                value = textEmail,
+                onValueChange = {
+                    viewModel.onEvent(TextEmailChanged(it))
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Email
+                )
+            )
+            TextField(
+                value = textPass,
+                onValueChange = {
+                    viewModel.onEvent(TextPassChanged(it))
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password
+                )
+            )
+            Button(
+                enabled = buttonsEnabled,
+                onClick = {
+                    viewModel.onEventDebounced(ClickedLogin)
+                }
+            ) {
+                Text(text = stringResource(R.string.login_login_button))
+            }
+            OutlinedButton(
+                enabled = buttonsEnabled,
+                onClick = {
+                    viewModel.onEventDebounced(ClickedRegister)
+                }) {
+                Text(text = stringResource(R.string.login_register_button))
+            }
+            TextButton(
+                enabled = buttonsEnabled,
+                onClick = {
+                    viewModel.onEventDebounced(ClickedForgotPassword)
+                }) {
+                Text(text = stringResource(R.string.login_forgot_password_button))
+            }
+        }
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreenModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreenModels.kt
@@ -12,6 +12,7 @@ sealed interface LoginScreenViewEvent : ViewEvent {
 }
 
 data class LoginScreenViewState(
+    val buttonsEnabled: Boolean,
     val textEmail: String,
     val textPass: String
 ) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreen.kt
@@ -1,12 +1,16 @@
 package com.dodo.flashcards.presentation.registerScreen
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import com.dodo.flashcards.R
@@ -16,7 +20,11 @@ import com.dodo.flashcards.presentation.registerScreen.RegisterScreenViewEvent.*
 fun RegisterScreen(viewModel: RegisterScreenViewModel) {
     viewModel.viewState.collectAsState().value?.apply {
         // Todo, clean up UI
-        Column {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
             TextField(
                 value = textEmail,
                 onValueChange = {
@@ -36,8 +44,9 @@ fun RegisterScreen(viewModel: RegisterScreenViewModel) {
                 )
             )
             Button(
+                enabled = buttonsEnabled,
                 onClick = {
-                    viewModel.onEvent(ClickedRegister)
+                    viewModel.onEventDebounced(ClickedRegister)
                 }
             ) {
                 Text(text = stringResource(R.string.register_register_button))

--- a/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreenModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreenModels.kt
@@ -11,6 +11,7 @@ sealed interface RegisterScreenViewEvent : ViewEvent {
 }
 
 data class RegisterScreenViewState(
+    val buttonsEnabled: Boolean,
     val textEmail: String,
     val textPass: String
 ) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreenViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreenViewModel.kt
@@ -2,12 +2,14 @@ package com.dodo.flashcards.presentation.registerScreen
 
 import androidx.lifecycle.viewModelScope
 import com.dodo.flashcards.architecture.BaseRoutingViewModel
-import com.dodo.flashcards.domain.usecases.RegisterUserUseCase
+import com.dodo.flashcards.domain.usecases.authentication.RegisterUserUseCase
 import com.dodo.flashcards.presentation.MainDestination
+import com.dodo.flashcards.presentation.MainDestination.*
 import com.dodo.flashcards.presentation.registerScreen.RegisterScreenViewEvent.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -18,6 +20,7 @@ class RegisterScreenViewModel @Inject constructor(
     init {
         pushState(
             RegisterScreenViewState(
+                buttonsEnabled = true,
                 textEmail = String(),
                 textPass = String()
             )
@@ -34,12 +37,16 @@ class RegisterScreenViewModel @Inject constructor(
 
     private fun onClickedRegister() {
         withLastState {
+            copy(buttonsEnabled = false).push()
             viewModelScope.launch(Dispatchers.IO) {
                 registerUserUseCase(textEmail, textPass)
                     .doOnSuccess {
-                        // Todo: Route to LoginScreen
+                        withContext(Dispatchers.Main) {
+                            routeTo(NavigateWelcome)
+                        }
                     }
                     .doOnError {
+                        copy(buttonsEnabled = true).push()
                         // Todo: Send error ViewState
                     }
             }

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
@@ -1,15 +1,31 @@
 package com.dodo.flashcards.presentation.welcomeScreen
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.dodo.flashcards.R
+import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewEvent.*
 
 @Composable
 fun WelcomeScreen(viewModel: WelcomeScreenViewModel) {
-    // Todo remove placeholder
-    Text("Welcome placeholder")
-
     viewModel.viewState.collectAsState().value?.apply {
-
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Button(onClick = {
+                viewModel.onEventDebounced(ClickedLogout)
+            }) {
+                Text(text = stringResource(R.string.welcome_logout_button))
+            }
+        }
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreenViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreenViewModel.kt
@@ -1,17 +1,29 @@
 package com.dodo.flashcards.presentation.welcomeScreen
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import com.dodo.flashcards.architecture.BaseRoutingViewModel
+import com.dodo.flashcards.domain.usecases.authentication.LogoutUserUseCase
 import com.dodo.flashcards.presentation.MainDestination
+import com.dodo.flashcards.presentation.MainDestination.*
 import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewEvent.ClickedLogout
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 
 @HiltViewModel
 class WelcomeScreenViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    private val logoutUserUseCase: LogoutUserUseCase
 ) : BaseRoutingViewModel<WelcomeScreenViewState, WelcomeScreenViewEvent, MainDestination>() {
+
+    init {
+        pushState(
+            WelcomeScreenViewState(
+                displayName = "TODO implement display name"
+            )
+        )
+    }
 
     override fun onEvent(event: WelcomeScreenViewEvent) {
         when (event) {
@@ -20,6 +32,9 @@ class WelcomeScreenViewModel @Inject constructor(
     }
 
     private fun onClickedLogout() {
-
+        viewModelScope.launch {
+            logoutUserUseCase()
+            routeTo(NavigateLogin)
+        }
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/util/Screen.kt
+++ b/app/src/main/java/com/dodo/flashcards/util/Screen.kt
@@ -1,17 +1,14 @@
 package com.dodo.flashcards.util
 
 sealed class Screen(val route: String) {
-    companion object{
 
-    }
-
+    object Categories : Screen("Category")
+    object CreateCategory : Screen("AddCategory")
+    object Decks : Screen("Decks")
     object Login : Screen("Login")
     object Register : Screen("Register")
     object Welcome : Screen("Welcome")
 
-    object Categories : Screen("Category")
-    object Decks : Screen("Decks")
-    object CreateCategory : Screen("AddCategory")
 
     fun withArgs(args: Array<Pair<String, String>>? = null) : String{
         return buildString {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,16 @@
 <resources>
     <string name="app_name">FlashcardsApp</string>
+
+    <!-- Text shown on button which a user clicks on if they forgot their password -->
+    <string name="login_forgot_password_button">Forgot Password?</string>
+    <!-- Text shown on button which will prompt a user to login with their credentials -->
+    <string name="login_login_button">Login</string>
+    <!-- Text shown on button which will prompt a user to begin registration -->
+    <string name="login_register_button">Register</string>
+
     <!-- Text shown on button which will register a user -->
     <string name="register_register_button">Register</string>
+
+    <!-- Text shown on button which will logout an authenticated user -->
+    <string name="welcome_logout_button">Logout</string>
 </resources>


### PR DESCRIPTION
**Background:**

Currently, only registration is possible in the app, with no ability to login or out once authenticated / unauthenticated.

**Changes:**

Add a crude implementation to `LoginScreen` to allow the user to login to their existing account, or to click to register a new account.

Add a button to `RegisterScreen` to allow the user to log out of an existing account.

**Testing:**

Open app. Attempt to login to an existing account correctly / incorrect, register a new account, log out.


https://user-images.githubusercontent.com/77797048/195246390-87aeff60-0b6f-47ba-854d-554103a6ffa6.mp4

cc: @mgerweck @brandonijones 

Closes #11
Closes #8
Closes #38