### PR TITLE
Crude forgot password implementation | #7 #9

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/dodo/flashcards/data/repository/AuthRepositoryImpl.kt
@@ -39,4 +39,13 @@ class AuthRepositoryImpl @Inject constructor(private val auth: FirebaseAuth) : A
     override suspend fun logout() {
         auth.signOut()
     }
+
+    override suspend fun sendPasswordResetEmail(email: String): Boolean {
+        return try {
+            auth.sendPasswordResetEmail(email).await()
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
 }

--- a/app/src/main/java/com/dodo/flashcards/domain/models/AuthRepository.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/models/AuthRepository.kt
@@ -17,4 +17,6 @@ interface AuthRepository {
     ): Resource<FirebaseUser>
 
     suspend fun logout()
+
+    suspend fun sendPasswordResetEmail(email: String): Boolean
 }

--- a/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/ForgotPassSendEmailUseCase.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/ForgotPassSendEmailUseCase.kt
@@ -1,0 +1,12 @@
+package com.dodo.flashcards.domain.usecases.authentication
+
+import com.dodo.flashcards.domain.models.AuthRepository
+import com.dodo.flashcards.util.Resource
+import com.google.firebase.auth.FirebaseUser
+import javax.inject.Inject
+
+class ForgotPassSendEmailUseCase @Inject constructor(private val authRepository: AuthRepository) {
+    suspend operator fun invoke(email: String): Boolean {
+        return authRepository.sendPasswordResetEmail(email)
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
@@ -41,11 +41,16 @@ class MainActivity : ComponentActivity(), Router<MainDestination> {
 
     override fun routeTo(destination: MainDestination) {
         when (destination) {
+            is NavigateForgotPass -> navigateForgotPass()
             is NavigateLogin -> navigateLogin()
             is NavigateRegister -> navigateRegister()
             is NavigateUp -> navigateUp()
             is NavigateWelcome -> navigateWelcome()
         }
+    }
+
+    private fun navigateForgotPass() {
+        navController.navigate(route = ForgotPass.route)
     }
 
     private fun navigateLogin() {

--- a/app/src/main/java/com/dodo/flashcards/presentation/MainModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainModels.kt
@@ -3,7 +3,6 @@ package com.dodo.flashcards.presentation
 import com.dodo.flashcards.architecture.Destination
 import com.dodo.flashcards.architecture.ViewEvent
 import com.dodo.flashcards.architecture.ViewState
-import com.google.firebase.auth.FirebaseAuth
 
 sealed interface MainViewState : ViewState {
     object Authenticated : MainViewState
@@ -14,6 +13,7 @@ sealed interface MainViewEvent : ViewEvent {
 }
 
 sealed interface MainDestination : Destination {
+    object NavigateForgotPass : MainDestination
     object NavigateLogin : MainDestination
     object NavigateRegister : MainDestination
     object NavigateUp : MainDestination

--- a/app/src/main/java/com/dodo/flashcards/presentation/MainNavHost.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainNavHost.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.dodo.flashcards.architecture.Router
+import com.dodo.flashcards.presentation.forgotPass.ForgotPassScreen
+import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewModel
 import com.dodo.flashcards.presentation.loginScreen.LoginScreen
 import com.dodo.flashcards.presentation.loginScreen.LoginScreenViewModel
 import com.dodo.flashcards.presentation.registerScreen.RegisterScreen
@@ -26,6 +28,11 @@ fun MainNavHost(
         navController = navController,
         startDestination = startRoute
     ) {
+        composable(route = ForgotPass.route) {
+            ForgotPassScreen(viewModel = hiltViewModel<ForgotPassViewModel>().apply {
+                attachRouter(router)
+            })
+        }
         composable(route = Login.route) {
             LoginScreen(viewModel = hiltViewModel<LoginScreenViewModel>().apply {
                 attachRouter(router)

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPass/ForgotPassModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPass/ForgotPassModels.kt
@@ -1,0 +1,18 @@
+package com.dodo.flashcards.presentation.forgotPass
+
+import com.dodo.flashcards.architecture.ViewEvent
+import com.dodo.flashcards.architecture.ViewState
+
+sealed interface ForgotPassViewEvent : ViewEvent {
+    object ClickedConfirmEmail : ForgotPassViewEvent
+    object ClickedReturn : ForgotPassViewEvent
+    data class TextChangedEmail(val changedTo: String) : ForgotPassViewEvent
+}
+
+sealed interface ForgotPassViewState : ViewState {
+    val textEmail: String
+
+    data class InputEmail(override val textEmail: String) : ForgotPassViewState
+    data class InvalidEmail(override val textEmail: String) : ForgotPassViewState
+    data class PendingConfirmation(override val textEmail: String) : ForgotPassViewState
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPass/ForgotPassScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPass/ForgotPassScreen.kt
@@ -1,0 +1,61 @@
+package com.dodo.flashcards.presentation.forgotPass
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import com.dodo.flashcards.R
+import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewEvent.*
+import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.PendingConfirmation
+import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.InputEmail
+import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.InvalidEmail
+
+@Composable
+fun ForgotPassScreen(viewModel: ForgotPassViewModel) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        viewModel.viewState.collectAsState().value?.apply {
+            when (this) {
+                is InputEmail -> {
+                    Text(stringResource(id = R.string.forgot_pass_prompt))
+                    TextField(
+                        value = textEmail,
+                        onValueChange = {
+                            viewModel.onEvent(TextChangedEmail(it))
+                        },
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Email
+                        )
+                    )
+                    Button(onClick = { viewModel.onEventDebounced(ClickedConfirmEmail) }) {
+                        Text(stringResource(id = R.string.forgot_pass_email_button))
+                    }
+                }
+                is InvalidEmail -> {
+                    Text(stringResource(id = R.string.forgot_pass_invalid_email, textEmail))
+                    Button(onClick = { viewModel.onEventDebounced(ClickedReturn) }) {
+                        Text(stringResource(R.string.forgot_pass_return_button))
+                    }
+                }
+                is PendingConfirmation -> {
+                    Text(stringResource(id = R.string.forgot_pass_confirmation, textEmail))
+                    Button(onClick = { viewModel.onEventDebounced(ClickedReturn) }) {
+                        Text(stringResource(R.string.forgot_pass_return_button))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPass/ForgotPassViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPass/ForgotPassViewModel.kt
@@ -1,0 +1,51 @@
+package com.dodo.flashcards.presentation.forgotPass
+
+import androidx.lifecycle.viewModelScope
+import com.dodo.flashcards.architecture.BaseRoutingViewModel
+import com.dodo.flashcards.domain.usecases.authentication.ForgotPassSendEmailUseCase
+import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.*
+import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewEvent.*
+import com.dodo.flashcards.presentation.MainDestination.*
+import com.dodo.flashcards.presentation.MainDestination
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ForgotPassViewModel @Inject constructor(
+    private val forgotPassSendEmailUseCase: ForgotPassSendEmailUseCase
+) : BaseRoutingViewModel<ForgotPassViewState, ForgotPassViewEvent, MainDestination>() {
+
+    init {
+        pushState(InputEmail(textEmail = String()))
+    }
+
+    override fun onEvent(event: ForgotPassViewEvent) {
+        when (event) {
+            is ClickedConfirmEmail -> onClickedConfirmEmail()
+            is ClickedReturn -> onClickedReturn()
+            is TextChangedEmail -> onTextChangedEmail(event)
+        }
+    }
+
+    private fun onClickedConfirmEmail() {
+        viewModelScope.launch(Dispatchers.IO) {
+            lastPushedState?.apply {
+                if (forgotPassSendEmailUseCase(textEmail)) {
+                    PendingConfirmation(textEmail)
+                } else {
+                    InvalidEmail(textEmail)
+                }.push()
+            }
+        }
+    }
+
+    private fun onClickedReturn() {
+        routeTo(NavigateLogin)
+    }
+
+    private fun onTextChangedEmail(event: TextChangedEmail) {
+        (lastPushedState as? InputEmail)?.copy(textEmail = event.changedTo)?.push()
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreenViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreenViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.dodo.flashcards.architecture.BaseRoutingViewModel
 import com.dodo.flashcards.domain.usecases.authentication.LoginUserUseCase
 import com.dodo.flashcards.presentation.MainDestination
+import com.dodo.flashcards.presentation.MainDestination.NavigateForgotPass
 import com.dodo.flashcards.presentation.MainDestination.NavigateRegister
 import com.dodo.flashcards.presentation.MainDestination.NavigateWelcome
 import com.dodo.flashcards.presentation.loginScreen.LoginScreenViewEvent.*
@@ -39,7 +40,7 @@ class LoginScreenViewModel @Inject constructor(
     }
 
     private fun onClickedForgotPassword() {
-
+        routeTo(NavigateForgotPass)
     }
 
     private fun onClickedLogin() {

--- a/app/src/main/java/com/dodo/flashcards/util/Screen.kt
+++ b/app/src/main/java/com/dodo/flashcards/util/Screen.kt
@@ -5,6 +5,7 @@ sealed class Screen(val route: String) {
     object Categories : Screen("Category")
     object CreateCategory : Screen("AddCategory")
     object Decks : Screen("Decks")
+    object ForgotPass : Screen("ForgotPass")
     object Login : Screen("Login")
     object Register : Screen("Register")
     object Welcome : Screen("Welcome")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,23 @@
 
     <!-- Text shown on button which will logout an authenticated user -->
     <string name="welcome_logout_button">Logout</string>
+
+    <!-- Text shown on header prompting user to enter their email to reset password -->
+    <string name="forgot_pass_prompt">
+        Enter the e-mail address associated with your account.
+    </string>
+    <!-- Text shown on the button prompting user to use the email they have input to reset the password -->
+    <string name="forgot_pass_email_button">
+        Send Password Reset E-mail
+    </string>
+    <!-- Text shown on the header after user has confirmed their e-mail for password reset -->
+    <string name="forgot_pass_confirmation">
+        If %s is a registered account, an e-mail has been sent to reset your password.
+    </string>
+    <!-- Text shown on the header after user has confirmed an invalid e-mail -->
+    <string name="forgot_pass_invalid_email">
+        %s is not a valid e-mail.
+    </string>
+    <!-- Text shown on button which will return user back to the Login screen -->
+    <string name="forgot_pass_return_button">Return</string>
 </resources>


### PR DESCRIPTION
**Background:**

It is important for a user to be able to reset their password from the application if necessary. There is currently a button on the login screen to reset, but it has no function.

**Changes**

This commit adds a functional, crude forgot password flow to the application. The user will click forgot password and enter an email. If the email is valid or invalid they are informed of that. They must then navigate to their e-mail and reset it from the link provided.

**Testing**

Open the application, click `Forgot Password` on the login screen, ensure the flow is logical when the e-mail entered is both valid and invalid.

Closes #7
Closes #9