### PR TITLE
feat: Crude username in registration impl | #32

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/domain/models/AuthRepository.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/models/AuthRepository.kt
@@ -6,9 +6,10 @@ import com.google.firebase.auth.FirebaseUser
 interface AuthRepository {
     suspend fun getCurrentUser(): FirebaseUser?
 
-    suspend fun registerUser(
+    suspend fun registerUserWithUsername(
         email: String,
-        password: String
+        password: String,
+        username: String
     ): Resource<FirebaseUser>
 
     suspend fun login(

--- a/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/GetUserUseCase.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/GetUserUseCase.kt
@@ -1,4 +1,0 @@
-package com.dodo.flashcards.domain.usecases.authentication
-
-class GetUserUseCase {
-}

--- a/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/RegisterUserUseCase.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/RegisterUserUseCase.kt
@@ -8,8 +8,9 @@ import javax.inject.Inject
 class RegisterUserUseCase @Inject constructor(private val authRepository: AuthRepository) {
     suspend operator fun invoke(
         email: String,
-        password: String
+        password: String,
+        username: String
     ): Resource<FirebaseUser> {
-        return authRepository.registerUser(email, password)
+        return authRepository.registerUserWithUsername(email, password, username)
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreen.kt
@@ -25,6 +25,17 @@ fun RegisterScreen(viewModel: RegisterScreenViewModel) {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
+            Text("USERNAME") // Todo, remove this with polish
+            TextField(
+                value = textUsername,
+                onValueChange = {
+                    viewModel.onEvent(TextUsernameChanged(changedTo = it))
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Text
+                )
+            )
+            Text("EMAIL") // Todo, remove this with polish
             TextField(
                 value = textEmail,
                 onValueChange = {
@@ -34,6 +45,7 @@ fun RegisterScreen(viewModel: RegisterScreenViewModel) {
                     keyboardType = KeyboardType.Email
                 )
             )
+            Text("PASSWORD") // Todo, remove this with polish
             TextField(
                 value = textPass,
                 onValueChange = {

--- a/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreenModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreenModels.kt
@@ -7,11 +7,12 @@ sealed interface RegisterScreenViewEvent : ViewEvent {
     object ClickedRegister : RegisterScreenViewEvent
     data class TextEmailChanged(val changedTo: String) : RegisterScreenViewEvent
     data class TextPassChanged(val changedTo: String) : RegisterScreenViewEvent
-    // Todo, add remaining text change events when we finalize what info we will collect
+    data class TextUsernameChanged(val changedTo: String) : RegisterScreenViewEvent
 }
 
 data class RegisterScreenViewState(
     val buttonsEnabled: Boolean,
     val textEmail: String,
-    val textPass: String
+    val textPass: String,
+    val textUsername: String
 ) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreenViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreenViewModel.kt
@@ -22,7 +22,8 @@ class RegisterScreenViewModel @Inject constructor(
             RegisterScreenViewState(
                 buttonsEnabled = true,
                 textEmail = String(),
-                textPass = String()
+                textPass = String(),
+                textUsername = String()
             )
         )
     }
@@ -32,6 +33,7 @@ class RegisterScreenViewModel @Inject constructor(
             is ClickedRegister -> onClickedRegister()
             is TextEmailChanged -> onTextEmailChanged(event)
             is TextPassChanged -> onTextPassChanged(event)
+            is TextUsernameChanged -> onTextUsernameChanged(event)
         }
     }
 
@@ -39,7 +41,7 @@ class RegisterScreenViewModel @Inject constructor(
         withLastState {
             copy(buttonsEnabled = false).push()
             viewModelScope.launch(Dispatchers.IO) {
-                registerUserUseCase(textEmail, textPass)
+                registerUserUseCase(textEmail, textPass, textUsername)
                     .doOnSuccess {
                         withContext(Dispatchers.Main) {
                             routeTo(NavigateWelcome)
@@ -54,15 +56,16 @@ class RegisterScreenViewModel @Inject constructor(
     }
 
     private fun onTextEmailChanged(event: TextEmailChanged) {
-        withLastState {
-            copy(textEmail = event.changedTo).push()
-        }
+        lastPushedState?.copy(textEmail = event.changedTo)?.push()
+
     }
 
     private fun onTextPassChanged(event: TextPassChanged) {
-        withLastState {
-            copy(textPass = event.changedTo).push()
-        }
+        lastPushedState?.copy(textPass = event.changedTo)?.push()
+    }
+
+    private fun onTextUsernameChanged(event: TextUsernameChanged) {
+        lastPushedState?.copy(textUsername = event.changedTo)?.push()
     }
 
     private inline fun withLastState(block: RegisterScreenViewState.() -> Unit) {

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
@@ -21,6 +21,11 @@ fun WelcomeScreen(viewModel: WelcomeScreenViewModel) {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
+            Text(
+                text = username?.let {
+                    stringResource(R.string.welcome_message_username, it)
+                } ?: stringResource(R.string.welcome_error_username)
+            )
             Button(onClick = {
                 viewModel.onEventDebounced(ClickedLogout)
             }) {

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreenModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreenModels.kt
@@ -7,6 +7,4 @@ sealed interface WelcomeScreenViewEvent : ViewEvent {
     object ClickedLogout : WelcomeScreenViewEvent
 }
 
-data class WelcomeScreenViewState(
-    val displayName: String
-) : ViewState
+data class WelcomeScreenViewState(val username: String?) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreenViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreenViewModel.kt
@@ -1,12 +1,12 @@
 package com.dodo.flashcards.presentation.welcomeScreen
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.dodo.flashcards.architecture.BaseRoutingViewModel
 import com.dodo.flashcards.domain.usecases.authentication.LogoutUserUseCase
 import com.dodo.flashcards.presentation.MainDestination
-import com.dodo.flashcards.presentation.MainDestination.*
+import com.dodo.flashcards.presentation.MainDestination.NavigateLogin
 import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewEvent.ClickedLogout
+import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -14,15 +14,12 @@ import javax.inject.Inject
 
 @HiltViewModel
 class WelcomeScreenViewModel @Inject constructor(
-    private val logoutUserUseCase: LogoutUserUseCase
+    private val logoutUserUseCase: LogoutUserUseCase,
+    firebaseAuth: FirebaseAuth,
 ) : BaseRoutingViewModel<WelcomeScreenViewState, WelcomeScreenViewEvent, MainDestination>() {
 
     init {
-        pushState(
-            WelcomeScreenViewState(
-                displayName = "TODO implement display name"
-            )
-        )
+        WelcomeScreenViewState(firebaseAuth.currentUser?.displayName).push()
     }
 
     override fun onEvent(event: WelcomeScreenViewEvent) {

--- a/app/src/main/java/com/dodo/flashcards/util/Screen.kt
+++ b/app/src/main/java/com/dodo/flashcards/util/Screen.kt
@@ -10,8 +10,7 @@ sealed class Screen(val route: String) {
     object Register : Screen("Register")
     object Welcome : Screen("Welcome")
 
-
-    fun withArgs(args: Array<Pair<String, String>>? = null) : String{
+    fun withArgs(args: Array<Pair<String, String>>? = null): String {
         return buildString {
             append(route)
             args?.forEachIndexed { index, pair ->
@@ -23,5 +22,5 @@ sealed class Screen(val route: String) {
         }
     }
 
-    override fun toString() : String = route
+    override fun toString(): String = route
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,10 @@
 
     <!-- Text shown on button which will logout an authenticated user -->
     <string name="welcome_logout_button">Logout</string>
+    <!-- Text shown when a user has logged in to welcome them by their username -->
+    <string name="welcome_message_username">Welcome %s</string>
+    <!-- Text shown when unable to correctly fetch a username for this user -->
+    <string name="welcome_error_username">Unknown</string>
 
     <!-- Text shown on header prompting user to enter their email to reset password -->
     <string name="forgot_pass_prompt">


### PR DESCRIPTION
**Background:**

During registration, we currently only retrieve e-mail and password - the minimum necessary information to register account. This commit adds a new field that must be completed during registration: username - and welcomes the user by their username in the welcome screen.

**Changes:**

* Update models of `RegisterScreen` & `WelcomeScreen` to include use of username.
* Update `AuthRepository` to require a username in the sign-up method.
* Do some minor clean-up.

**Testing:**

Open the application. When registering, you should now see a username field. When registered, and when you login, you should now see "Welcome 'username'". If the account does not have a username, it should just say unknown.

cc @mgerweck @brandonijones 

Closes #32

10 & 31 have also been closed for some time, and this is related to that so - 
Closes #10
Closes #31 