### PR TITLE
feat: Stub out navigation related to Edit Profile | #53

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
@@ -41,12 +41,27 @@ class MainActivity : ComponentActivity(), Router<MainDestination> {
 
     override fun routeTo(destination: MainDestination) {
         when (destination) {
+            is NavigateEditUsername -> navigateEditUsername()
+            is NavigateEditPass -> navigateEditPass()
+            is NavigateEditProfile -> navigateEditProfile()
             is NavigateForgotPass -> navigateForgotPass()
             is NavigateLogin -> navigateLogin()
             is NavigateRegister -> navigateRegister()
             is NavigateUp -> navigateUp()
             is NavigateWelcome -> navigateWelcome()
         }
+    }
+
+    private fun navigateEditUsername() {
+        navController.navigate(route = EditUsername.route)
+    }
+
+    private fun navigateEditPass() {
+        navController.navigate(route = EditPass.route)
+    }
+
+    private fun navigateEditProfile() {
+        navController.navigate(route = EditProfile.route)
     }
 
     private fun navigateForgotPass() {

--- a/app/src/main/java/com/dodo/flashcards/presentation/MainModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainModels.kt
@@ -13,6 +13,9 @@ sealed interface MainViewEvent : ViewEvent {
 }
 
 sealed interface MainDestination : Destination {
+    object NavigateEditPass : MainDestination
+    object NavigateEditProfile : MainDestination
+    object NavigateEditUsername : MainDestination
     object NavigateForgotPass : MainDestination
     object NavigateLogin : MainDestination
     object NavigateRegister : MainDestination

--- a/app/src/main/java/com/dodo/flashcards/presentation/MainNavHost.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainNavHost.kt
@@ -5,8 +5,14 @@ import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.dodo.flashcards.architecture.Router
-import com.dodo.flashcards.presentation.forgotPass.ForgotPassScreen
-import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewModel
+import com.dodo.flashcards.presentation.editProfileScreen.EditProfileScreen
+import com.dodo.flashcards.presentation.editProfileScreen.EditProfileViewModel
+import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editPass.EditPassScreen
+import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editPass.EditPassViewModel
+import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsername.EditUsernameScreen
+import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsername.EditUsernameViewModel
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassScreen
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewModel
 import com.dodo.flashcards.presentation.loginScreen.LoginScreen
 import com.dodo.flashcards.presentation.loginScreen.LoginScreenViewModel
 import com.dodo.flashcards.presentation.registerScreen.RegisterScreen
@@ -28,6 +34,21 @@ fun MainNavHost(
         navController = navController,
         startDestination = startRoute
     ) {
+        composable(route = EditUsername.route) {
+            EditUsernameScreen(viewModel = hiltViewModel<EditUsernameViewModel>().apply {
+                attachRouter(router)
+            })
+        }
+        composable(route = EditPass.route) {
+            EditPassScreen(viewModel = hiltViewModel<EditPassViewModel>().apply {
+                attachRouter(router)
+            })
+        }
+        composable(route = EditProfile.route) {
+            EditProfileScreen(viewModel = hiltViewModel<EditProfileViewModel>().apply {
+                attachRouter(router)
+            })
+        }
         composable(route = ForgotPass.route) {
             ForgotPassScreen(viewModel = hiltViewModel<ForgotPassViewModel>().apply {
                 attachRouter(router)

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/EditProfileModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/EditProfileModels.kt
@@ -1,0 +1,12 @@
+package com.dodo.flashcards.presentation.editProfileScreen
+
+import com.dodo.flashcards.architecture.ViewEvent
+import com.dodo.flashcards.architecture.ViewState
+
+sealed interface EditProfileViewEvent : ViewEvent {
+    object ClickedEditUsername : EditProfileViewEvent
+    object ClickedEditPassword : EditProfileViewEvent
+    object ClickedReturn : EditProfileViewEvent
+}
+
+object EditProfileViewState : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/EditProfileScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/EditProfileScreen.kt
@@ -1,0 +1,35 @@
+package com.dodo.flashcards.presentation.editProfileScreen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.dodo.flashcards.presentation.editProfileScreen.EditProfileViewEvent.*
+
+@Composable
+fun EditProfileScreen(viewModel: EditProfileViewModel) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        viewModel.viewState.collectAsState().value?.apply {
+            Text(text = "Edit Profile")
+            TextButton(onClick = { viewModel.onEventDebounced(ClickedEditUsername) }) {
+                Text("Edit Username")
+            }
+            TextButton(onClick = { viewModel.onEventDebounced(ClickedEditPassword) }) {
+                Text("Edit Password")
+            }
+            Button(onClick = { viewModel.onEventDebounced(ClickedReturn) }) {
+                Text("Return")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/EditProfileViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/EditProfileViewModel.kt
@@ -1,0 +1,37 @@
+package com.dodo.flashcards.presentation.editProfileScreen
+
+import com.dodo.flashcards.architecture.BaseRoutingViewModel
+import com.dodo.flashcards.presentation.MainDestination
+import com.dodo.flashcards.presentation.MainDestination.*
+import com.dodo.flashcards.presentation.editProfileScreen.EditProfileViewEvent.*
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class EditProfileViewModel @Inject constructor() :
+    BaseRoutingViewModel<EditProfileViewState, EditProfileViewEvent, MainDestination>() {
+
+    init {
+        pushState(EditProfileViewState)
+    }
+
+    override fun onEvent(event: EditProfileViewEvent) {
+        when (event) {
+            is ClickedEditPassword -> onClickedEditPassword()
+            is ClickedEditUsername -> onClickedEditUsername()
+            is ClickedReturn -> onClickedReturn()
+        }
+    }
+
+    private fun onClickedEditPassword() {
+        routeTo(NavigateEditPass)
+    }
+
+    private fun onClickedEditUsername() {
+        routeTo(NavigateEditUsername)
+    }
+
+    private fun onClickedReturn() {
+        routeTo(NavigateUp)
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassModels.kt
@@ -1,0 +1,12 @@
+package com.dodo.flashcards.presentation.editProfileScreen.subscreens.editPass
+
+import com.dodo.flashcards.architecture.ViewEvent
+import com.dodo.flashcards.architecture.ViewState
+
+sealed interface EditPassViewEvent : ViewEvent {
+    object ClickedConfirm : EditPassViewEvent
+    object ClickedReturn : EditPassViewEvent
+    data class TextPassChanged(val changedTo: String) : EditPassViewEvent
+}
+
+data class EditPassViewState(val textPass: String) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassScreen.kt
@@ -1,0 +1,42 @@
+package com.dodo.flashcards.presentation.editProfileScreen.subscreens.editPass
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editPass.EditPassViewEvent.*
+
+@Composable
+fun EditPassScreen(viewModel: EditPassViewModel) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        viewModel.viewState.collectAsState().value?.apply {
+            Text("Edit Pass")
+            TextField(
+                value = textPass,
+                onValueChange = {
+                    viewModel.onEvent(TextPassChanged(it))
+                }
+            )
+            Button(onClick = {
+                viewModel.onEventDebounced(ClickedConfirm)
+            }) {
+                Text("Confirm")
+            }
+            Button(onClick = {
+                viewModel.onEventDebounced(ClickedReturn)
+            }) {
+                Text("Return")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassViewModel.kt
@@ -1,0 +1,37 @@
+package com.dodo.flashcards.presentation.editProfileScreen.subscreens.editPass
+
+import com.dodo.flashcards.architecture.BaseRoutingViewModel
+import com.dodo.flashcards.presentation.MainDestination
+import com.dodo.flashcards.presentation.MainDestination.NavigateUp
+import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editPass.EditPassViewEvent.*
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class EditPassViewModel @Inject constructor() :
+    BaseRoutingViewModel<EditPassViewState, EditPassViewEvent, MainDestination>() {
+
+    init {
+        pushState(EditPassViewState(textPass = String()))
+    }
+
+    override fun onEvent(event: EditPassViewEvent) {
+        when (event) {
+            is ClickedConfirm -> onClickedConfirm()
+            is ClickedReturn -> onClickedReturn()
+            is TextPassChanged -> onTextPassChanged(event)
+        }
+    }
+
+    private fun onClickedConfirm() {
+
+    }
+
+    private fun onClickedReturn() {
+        routeTo(NavigateUp)
+    }
+
+    private fun onTextPassChanged(event: TextPassChanged) {
+
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameModels.kt
@@ -1,0 +1,12 @@
+package com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsername
+
+import com.dodo.flashcards.architecture.ViewEvent
+import com.dodo.flashcards.architecture.ViewState
+
+sealed interface EditUsernameViewEvent : ViewEvent {
+    object ClickedConfirm : EditUsernameViewEvent
+    object ClickedReturn : EditUsernameViewEvent
+    data class TextUsernameChanged(val changedTo: String) : EditUsernameViewEvent
+}
+
+data class EditUsernameViewState(val textUsername: String) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameScreen.kt
@@ -1,0 +1,42 @@
+package com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsername
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsername.EditUsernameViewEvent.*
+
+@Composable
+fun EditUsernameScreen(viewModel: EditUsernameViewModel) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        viewModel.viewState.collectAsState().value?.apply {
+            Text("Edit Username")
+            TextField(
+                value = textUsername,
+                onValueChange = {
+                    viewModel.onEvent(TextUsernameChanged(it))
+                }
+            )
+            Button(onClick = {
+                viewModel.onEventDebounced(ClickedConfirm)
+            }) {
+                Text("Confirm")
+            }
+            Button(onClick = {
+                viewModel.onEventDebounced(ClickedReturn)
+            }) {
+                Text("Return")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameViewModel.kt
@@ -1,0 +1,37 @@
+package com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsername
+
+import com.dodo.flashcards.architecture.BaseRoutingViewModel
+import com.dodo.flashcards.presentation.MainDestination
+import com.dodo.flashcards.presentation.MainDestination.NavigateUp
+import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsername.EditUsernameViewEvent.*
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class EditUsernameViewModel @Inject constructor() :
+    BaseRoutingViewModel<EditUsernameViewState, EditUsernameViewEvent, MainDestination>() {
+
+    init {
+        EditUsernameViewState(textUsername = String()).push()
+    }
+
+    override fun onEvent(event: EditUsernameViewEvent) {
+        when (event) {
+            is ClickedConfirm -> onClickedConfirm()
+            is ClickedReturn -> onClickedReturn()
+            is TextUsernameChanged -> onTextUsernameChanged(event)
+        }
+    }
+
+    private fun onClickedConfirm() {
+
+    }
+
+    private fun onClickedReturn() {
+        routeTo(NavigateUp)
+    }
+
+    private fun onTextUsernameChanged(event: TextUsernameChanged) {
+
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassModels.kt
@@ -1,4 +1,4 @@
-package com.dodo.flashcards.presentation.forgotPass
+package com.dodo.flashcards.presentation.forgotPassScreen
 
 import com.dodo.flashcards.architecture.ViewEvent
 import com.dodo.flashcards.architecture.ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassScreen.kt
@@ -1,4 +1,4 @@
-package com.dodo.flashcards.presentation.forgotPass
+package com.dodo.flashcards.presentation.forgotPassScreen
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -14,10 +14,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import com.dodo.flashcards.R
-import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewEvent.*
-import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.PendingConfirmation
-import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.InputEmail
-import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.InvalidEmail
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewEvent.*
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.PendingConfirmation
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.InputEmail
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.InvalidEmail
 
 @Composable
 fun ForgotPassScreen(viewModel: ForgotPassViewModel) {

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassViewModel.kt
@@ -1,10 +1,10 @@
-package com.dodo.flashcards.presentation.forgotPass
+package com.dodo.flashcards.presentation.forgotPassScreen
 
 import androidx.lifecycle.viewModelScope
 import com.dodo.flashcards.architecture.BaseRoutingViewModel
 import com.dodo.flashcards.domain.usecases.authentication.ForgotPassSendEmailUseCase
-import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.*
-import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewEvent.*
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.*
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewEvent.*
 import com.dodo.flashcards.presentation.MainDestination.*
 import com.dodo.flashcards.presentation.MainDestination
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
@@ -31,6 +31,11 @@ fun WelcomeScreen(viewModel: WelcomeScreenViewModel) {
             }) {
                 Text(text = stringResource(R.string.welcome_logout_button))
             }
+            Button(onClick = {
+                viewModel.onEventDebounced(ClickedEditProfile)
+            }) {
+                Text(text = "Edit Profile")
+            }
         }
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreenModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreenModels.kt
@@ -4,6 +4,7 @@ import com.dodo.flashcards.architecture.ViewEvent
 import com.dodo.flashcards.architecture.ViewState
 
 sealed interface WelcomeScreenViewEvent : ViewEvent {
+    object ClickedEditProfile : WelcomeScreenViewEvent
     object ClickedLogout : WelcomeScreenViewEvent
 }
 

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreenViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreenViewModel.kt
@@ -4,13 +4,13 @@ import androidx.lifecycle.viewModelScope
 import com.dodo.flashcards.architecture.BaseRoutingViewModel
 import com.dodo.flashcards.domain.usecases.authentication.LogoutUserUseCase
 import com.dodo.flashcards.presentation.MainDestination
-import com.dodo.flashcards.presentation.MainDestination.NavigateLogin
+import com.dodo.flashcards.presentation.MainDestination.*
+import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewEvent.ClickedEditProfile
 import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewEvent.ClickedLogout
 import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
 
 @HiltViewModel
 class WelcomeScreenViewModel @Inject constructor(
@@ -24,8 +24,13 @@ class WelcomeScreenViewModel @Inject constructor(
 
     override fun onEvent(event: WelcomeScreenViewEvent) {
         when (event) {
+            is ClickedEditProfile -> onClickedEditProfile()
             is ClickedLogout -> onClickedLogout()
         }
+    }
+
+    private fun onClickedEditProfile() {
+        routeTo(NavigateEditProfile)
     }
 
     private fun onClickedLogout() {

--- a/app/src/main/java/com/dodo/flashcards/util/Screen.kt
+++ b/app/src/main/java/com/dodo/flashcards/util/Screen.kt
@@ -3,8 +3,11 @@ package com.dodo.flashcards.util
 sealed class Screen(val route: String) {
 
     object Categories : Screen("Category")
-    object CreateCategory : Screen("AddCategory")
+    object CreateCategory : Screen("CreateCategory")
     object Decks : Screen("Decks")
+    object EditPass : Screen("EditPass")
+    object EditProfile : Screen("EditProfile")
+    object EditUsername : Screen("EditUsername")
     object ForgotPass : Screen("ForgotPass")
     object Login : Screen("Login")
     object Register : Screen("Register")


### PR DESCRIPTION
**Background:**

We would like users to be able to edit their username and password from within the app. Currently, there are no screens yet defined that would allow us to add this feature. This commit adds a functional navigation flow from "Welcome" to all necessary edit profile screens.

**Changes:**
* Add `editProfileScreen` package and define two subpackages of `subscreens` within, one for username and one for password.
* Add necessary routes and navigation graph entries for these new screens.
* Minor style fix - rename `forgotPass` to `forgotPassScreen`.

**Testing:**
Open app, log-in (or register a new account). From the welcome screen you should see an `Edit Profile` button. Click it, you should be able to navigate around, but not input anything in text fields yet.

https://user-images.githubusercontent.com/77797048/195927663-cbd83a0e-fdd6-4321-a329-82aae98cfa2e.mp4

#53