### PR TITLE
feat: Add functional impl to edit username and password | #53

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/di/AppModule.kt
+++ b/app/src/main/java/com/dodo/flashcards/di/AppModule.kt
@@ -2,6 +2,7 @@ package com.dodo.flashcards.di
 
 import com.dodo.flashcards.data.repository.AuthRepositoryImpl
 import com.dodo.flashcards.domain.models.AuthRepository
+import com.dodo.flashcards.util.UserUtils
 import com.google.firebase.auth.FirebaseAuth
 import dagger.Module
 import dagger.Provides
@@ -20,4 +21,7 @@ object AppModule {
     fun provideAuthRepository(
         firebaseAuth: FirebaseAuth
     ): AuthRepository = AuthRepositoryImpl(firebaseAuth)
+
+    @Provides
+    fun provideUserUtils(): UserUtils = UserUtils()
 }

--- a/app/src/main/java/com/dodo/flashcards/domain/models/AuthRepository.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/models/AuthRepository.kt
@@ -18,6 +18,6 @@ interface AuthRepository {
 
     suspend fun logout(): Response<Unit>
     suspend fun sendPasswordResetEmail(email: String): Response<Unit>
-    suspend fun updatePassword(password: String): Response<Unit>
+    suspend fun updatePassword(oldPassword: String, newPassword: String): Response<Unit>
     suspend fun updateUsername(username: String): Response<Unit>
 }

--- a/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/UpdatePasswordUseCase.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/UpdatePasswordUseCase.kt
@@ -1,0 +1,15 @@
+package com.dodo.flashcards.domain.usecases.authentication
+
+import com.dodo.flashcards.domain.models.AuthRepository
+import com.dodo.flashcards.domain.models.User
+import com.dodo.flashcards.util.Response
+import javax.inject.Inject
+
+class UpdatePasswordUseCase @Inject constructor(private val authRepository: AuthRepository) {
+    suspend operator fun invoke(
+        oldPassword: String,
+        newPassword: String
+    ): Response<Unit> {
+        return authRepository.updatePassword(oldPassword, newPassword)
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/UpdateUsernameUseCase.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/usecases/authentication/UpdateUsernameUseCase.kt
@@ -1,0 +1,12 @@
+package com.dodo.flashcards.domain.usecases.authentication
+
+import com.dodo.flashcards.domain.models.AuthRepository
+import com.dodo.flashcards.domain.models.User
+import com.dodo.flashcards.util.Response
+import javax.inject.Inject
+
+class UpdateUsernameUseCase @Inject constructor(private val authRepository: AuthRepository) {
+    suspend operator fun invoke(username: String): Response<Unit> {
+        return authRepository.updateUsername(username)
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassModels.kt
@@ -6,7 +6,13 @@ import com.dodo.flashcards.architecture.ViewState
 sealed interface EditPassViewEvent : ViewEvent {
     object ClickedConfirm : EditPassViewEvent
     object ClickedReturn : EditPassViewEvent
-    data class TextPassChanged(val changedTo: String) : EditPassViewEvent
+    data class TextPassNewChanged(val changedTo: String) : EditPassViewEvent
+    data class TextPassOldChanged(val changedTo: String) : EditPassViewEvent
 }
 
-data class EditPassViewState(val textPass: String) : ViewState
+data class EditPassViewState(
+    val confirmButtonEnabled: Boolean,
+    val hasSuccessfullySet: Boolean,
+    val textPassNew: String,
+    val textPassOld: String
+) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassScreen.kt
@@ -23,18 +23,32 @@ fun EditPassScreen(viewModel: EditPassViewModel) {
     ) {
         viewModel.viewState.collectAsState().value?.apply {
             Text("Edit Pass")
+            Text("For security, enter your old password")
             TextField(
-                value = textPass,
+                value = textPassOld,
                 onValueChange = {
-                    viewModel.onEvent(TextPassChanged(it))
+                    viewModel.onEvent(TextPassOldChanged(it))
+                }
+            )
+            Text("Enter a new password")
+            Text("A password must be at least 6 characters")
+            TextField(
+                value = textPassNew,
+                onValueChange = {
+                    viewModel.onEvent(TextPassNewChanged(it))
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Password
                 )
             )
-            Button(onClick = {
-                viewModel.onEventDebounced(ClickedConfirm)
-            }) {
+            if (hasSuccessfullySet) {
+                Text("Successful update")
+            }
+            Button(
+                enabled = confirmButtonEnabled,
+                onClick = {
+                    viewModel.onEventDebounced(ClickedConfirm)
+                }) {
                 Text("Confirm")
             }
             Button(onClick = {

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassViewModel.kt
@@ -1,37 +1,89 @@
 package com.dodo.flashcards.presentation.editProfileScreen.subscreens.editPass
 
+import androidx.lifecycle.viewModelScope
 import com.dodo.flashcards.architecture.BaseRoutingViewModel
+import com.dodo.flashcards.domain.usecases.authentication.UpdatePasswordUseCase
 import com.dodo.flashcards.presentation.MainDestination
 import com.dodo.flashcards.presentation.MainDestination.NavigateUp
 import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editPass.EditPassViewEvent.*
+import com.dodo.flashcards.util.UserUtils
+import com.dodo.flashcards.util.doOnError
+import com.dodo.flashcards.util.doOnSuccess
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class EditPassViewModel @Inject constructor() :
+class EditPassViewModel @Inject constructor(
+    private val userUtils: UserUtils,
+    private val updatePasswordUseCase: UpdatePasswordUseCase
+) :
     BaseRoutingViewModel<EditPassViewState, EditPassViewEvent, MainDestination>() {
 
     init {
-        pushState(EditPassViewState(textPass = String()))
+        pushState(
+            EditPassViewState(
+                confirmButtonEnabled = false,
+                hasSuccessfullySet = false,
+                textPassNew = String(),
+                textPassOld = String()
+            )
+        )
     }
 
     override fun onEvent(event: EditPassViewEvent) {
         when (event) {
             is ClickedConfirm -> onClickedConfirm()
             is ClickedReturn -> onClickedReturn()
-            is TextPassChanged -> onTextPassChanged(event)
+            is TextPassNewChanged -> onTextPassNewChanged(event)
+            is TextPassOldChanged -> onTextPassOldChanged(event)
         }
     }
 
     private fun onClickedConfirm() {
-
+        viewModelScope.launch(Dispatchers.IO) {
+            lastPushedState?.apply {
+                copy(confirmButtonEnabled = false).push()
+                updatePasswordUseCase(
+                    oldPassword = textPassOld,
+                    newPassword = textPassNew
+                )
+                    .doOnSuccess {
+                        copy(
+                            confirmButtonEnabled = false,
+                            hasSuccessfullySet = true
+                        ).push()
+                    }
+                    .doOnError {
+                        // Todo, add some error response in ui
+                        // Todo, parse each exception and add a "try again error"
+                        // for FirebaseTooManyRequestsException
+                        copy(
+                            confirmButtonEnabled = true,
+                            hasSuccessfullySet = false
+                        ).push()
+                    }
+            }
+        }
     }
 
     private fun onClickedReturn() {
         routeTo(NavigateUp)
     }
 
-    private fun onTextPassChanged(event: TextPassChanged) {
-        lastPushedState?.copy(textPass = event.changedTo)?.push()
+    private fun onTextPassNewChanged(event: TextPassNewChanged) {
+        lastPushedState?.copy(
+            confirmButtonEnabled = userUtils.isValidPassword(event.changedTo),
+            hasSuccessfullySet = false,
+            textPassNew = event.changedTo
+        )?.push()
+    }
+
+    private fun onTextPassOldChanged(event: TextPassOldChanged) {
+        lastPushedState?.copy(
+            hasSuccessfullySet = false,
+            textPassOld = event.changedTo
+        )?.push()
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameModels.kt
@@ -9,4 +9,8 @@ sealed interface EditUsernameViewEvent : ViewEvent {
     data class TextUsernameChanged(val changedTo: String) : EditUsernameViewEvent
 }
 
-data class EditUsernameViewState(val textUsername: String) : ViewState
+data class EditUsernameViewState(
+    val confirmButtonEnabled: Boolean,
+    val hasSuccessfullySet: Boolean,
+    val textUsername: String,
+) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameScreen.kt
@@ -27,9 +27,14 @@ fun EditUsernameScreen(viewModel: EditUsernameViewModel) {
                     viewModel.onEvent(TextUsernameChanged(it))
                 }
             )
-            Button(onClick = {
-                viewModel.onEventDebounced(ClickedConfirm)
-            }) {
+            if (hasSuccessfullySet) {
+                Text("Successful update")
+            }
+            Button(
+                enabled = confirmButtonEnabled,
+                onClick = {
+                    viewModel.onEventDebounced(ClickedConfirm)
+                }) {
                 Text("Confirm")
             }
             Button(onClick = {

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameViewModel.kt
@@ -1,18 +1,42 @@
 package com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsername
 
+import androidx.lifecycle.viewModelScope
 import com.dodo.flashcards.architecture.BaseRoutingViewModel
+import com.dodo.flashcards.domain.usecases.authentication.GetUserUseCase
+import com.dodo.flashcards.domain.usecases.authentication.UpdateUsernameUseCase
 import com.dodo.flashcards.presentation.MainDestination
 import com.dodo.flashcards.presentation.MainDestination.NavigateUp
 import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsername.EditUsernameViewEvent.*
+import com.dodo.flashcards.util.UserUtils
+import com.dodo.flashcards.util.doOnError
+import com.dodo.flashcards.util.doOnSuccess
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class EditUsernameViewModel @Inject constructor() :
+class EditUsernameViewModel @Inject constructor(
+    private val getUserUseCase: GetUserUseCase,
+    private val userUtils: UserUtils,
+    private val updateUsernameUseCase: UpdateUsernameUseCase,
+) :
     BaseRoutingViewModel<EditUsernameViewState, EditUsernameViewEvent, MainDestination>() {
 
+    private lateinit var lastSavedUsername: String
+
     init {
-        EditUsernameViewState(textUsername = String()).push()
+        viewModelScope.launch {
+            getUserUseCase()
+                .doOnSuccess {
+                    lastSavedUsername = data.username
+                    EditUsernameViewState(
+                        confirmButtonEnabled = false,
+                        textUsername = lastSavedUsername,
+                        hasSuccessfullySet = false
+                    ).push()
+                }
+        }
     }
 
     override fun onEvent(event: EditUsernameViewEvent) {
@@ -24,7 +48,26 @@ class EditUsernameViewModel @Inject constructor() :
     }
 
     private fun onClickedConfirm() {
-
+        viewModelScope.launch(Dispatchers.IO) {
+            lastPushedState?.apply {
+                copy(confirmButtonEnabled = false).push()
+                updateUsernameUseCase(textUsername)
+                    .doOnSuccess {
+                        lastSavedUsername = textUsername
+                        copy(
+                            confirmButtonEnabled = false,
+                            hasSuccessfullySet = true
+                        ).push()
+                    }
+                    .doOnError {
+                        // Todo, add some error response in ui
+                        copy(
+                            confirmButtonEnabled = true,
+                            hasSuccessfullySet = false
+                        ).push()
+                    }
+            }
+        }
     }
 
     private fun onClickedReturn() {
@@ -32,6 +75,13 @@ class EditUsernameViewModel @Inject constructor() :
     }
 
     private fun onTextUsernameChanged(event: TextUsernameChanged) {
-        lastPushedState?.copy(textUsername = event.changedTo)?.push()
+        lastPushedState?.copy(
+            confirmButtonEnabled = userUtils.isValidUsername(
+                username = event.changedTo,
+                oldUsername = lastSavedUsername
+            ),
+            textUsername = event.changedTo,
+            hasSuccessfullySet = false
+        )?.push()
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/util/UserUtils.kt
+++ b/app/src/main/java/com/dodo/flashcards/util/UserUtils.kt
@@ -1,0 +1,17 @@
+package com.dodo.flashcards.util
+
+class UserUtils {
+    
+    companion object {
+        private const val MINIMUM_PASSWORD_LENGTH = 6
+    }
+
+    fun isValidUsername(username: String, oldUsername: String? = null): Boolean {
+        // Todo, add all valid username change logic here
+        return username.isNotEmpty() && username != oldUsername
+    }
+
+    fun isValidPassword(password: String): Boolean {
+        return password.length >= MINIMUM_PASSWORD_LENGTH
+    }
+}


### PR DESCRIPTION
feat: Add functional impl to edit username and password | #53

**Background:**

Currently, though the navigation exists, it is not possible to edit your username or password - the confirm button had no functionality. This commit adds functionality to both edit username and edit password, allowing the user to do both in the application.

**Changes:**

* Add `UserUtils`, a utility file we can inject whenever we need to verify if an email or password is valid. The function within is placeholder for now.
* Change `EditPassScreen` to contain two text fields, prompting the user to input their old password in addition to a new password.
* Update `AuthRepository` and its impl to reauthenticate by accepting an old password parameter.
* When either property has been successfully set, inform the user.

**Testing:**

Open the app, click "Edit Profile" on the welcome screen, edit both the username and password - ensure they are updated.

Note: there is currently a visual "bug" where when you navigate up after changing the username it will not be reflected. This is not exactly a bug and is present on many applications when you make an edit due to the nature of how those updates would be made - but we can try to adjust this later.

Related to #53