### PR TITLE
style: Polish welcome, register, login UI | #33 #47 #48

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/presentation/common/CustomOutlinedTextFields.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/common/CustomOutlinedTextFields.kt
@@ -1,0 +1,75 @@
+package com.dodo.flashcards.presentation.registerScreen.composables
+
+import android.media.Image
+import android.text.BoringLayout
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material.icons.outlined.VisibilityOff
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.constraintlayout.widget.Placeholder
+import com.dodo.flashcards.R
+import com.dodo.flashcards.architecture.EventReceiver
+import com.dodo.flashcards.presentation.registerScreen.RegisterScreenViewEvent
+
+@Composable
+fun CustomOutlinedTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    placeholderText: String = String(),
+    keyboardType: KeyboardType,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = keyboardType
+        ),
+        label = {
+            Text(label)
+        },
+        placeholder = {
+            Text(placeholderText)
+        },
+    )
+}
+
+@Composable
+fun PasswordTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    placeholderText: String = String(),
+    keyboardType: KeyboardType,
+    onIconChanged: () -> Unit,
+    isHidden: Boolean,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = keyboardType
+        ),
+        label = {
+            Text(label)
+        },
+        placeholder = {
+            Text(placeholderText)
+        },
+        trailingIcon = {
+            IconButton(onClick = onIconChanged) {
+                Icon(
+                    imageVector = if (isHidden) Icons.Outlined.Visibility else Icons.Outlined.VisibilityOff,
+                    contentDescription = stringResource(R.string.password_visibility_description)
+                )
+            }
+        })
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassScreen.kt
@@ -13,11 +13,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
 import com.dodo.flashcards.R
-import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewEvent.*
-import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.PendingConfirmation
-import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.InputEmail
-import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.InvalidEmail
+import com.dodo.flashcards.domain.models.AuthRepository
+import com.dodo.flashcards.domain.usecases.authentication.ForgotPassSendEmailUseCase
+import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewEvent.*
+import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.PendingConfirmation
+import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.InputEmail
+import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.InvalidEmail
 
 @Composable
 fun ForgotPassScreen(viewModel: ForgotPassViewModel) {

--- a/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreen.kt
@@ -1,47 +1,70 @@
 package com.dodo.flashcards.presentation.loginScreen
 
+import android.graphics.Color
+import android.graphics.Paint
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import com.dodo.flashcards.R
 import com.dodo.flashcards.presentation.loginScreen.LoginScreenViewEvent.*
+import com.dodo.flashcards.presentation.registerScreen.composables.CustomOutlinedTextField
+import com.dodo.flashcards.presentation.registerScreen.composables.PasswordTextField
+import com.dodo.flashcards.presentation.theme.DarkColors
 
 @Composable
 fun LoginScreen(viewModel: LoginScreenViewModel) {
     viewModel.viewState.collectAsState().value?.apply {
         // Todo, clean up UI
         Column(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colors.primary)
+                .drawBehind {
+                    val path = Path()
+                    path.moveTo(0f, size.height * 0.05f)
+                    path.lineTo(size.width, 0.2f * size.height)
+                    path.lineTo(size.width, 0.95f * size.height)
+                    path.lineTo(0f, 0.8f * size.height)
+
+                    drawPath(
+                        path = path,
+                        color = DarkColors.background
+                    )
+                },
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
             Text(text = stringResource(id = R.string.app_name))
-            TextField(
+            CustomOutlinedTextField(
                 value = textEmail,
-                onValueChange = {
-                    viewModel.onEvent(TextEmailChanged(it))
-                },
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Email
-                )
+                onValueChange = { viewModel.onEvent(TextEmailChanged(it)) },
+                label = stringResource(R.string.general_email_label),
+                keyboardType = KeyboardType.Email,
             )
-            TextField(
+            PasswordTextField(
                 value = textPass,
-                onValueChange = {
-                    viewModel.onEvent(TextPassChanged(it))
+                onValueChange = { viewModel.onEvent(TextPassChanged(it)) },
+                label = stringResource(R.string.general_password_label),
+                keyboardType = KeyboardType.Password,
+                onIconChanged = {
+                    viewModel.onEvent(ClickedShowPassword)
                 },
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Password
-                )
+                isHidden = isHidden,
             )
+
             Button(
                 enabled = buttonsEnabled,
                 onClick = {

--- a/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreenModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreenModels.kt
@@ -7,6 +7,7 @@ sealed interface LoginScreenViewEvent : ViewEvent {
     object ClickedForgotPassword : LoginScreenViewEvent
     object ClickedLogin : LoginScreenViewEvent
     object ClickedRegister : LoginScreenViewEvent
+    object ClickedShowPassword : LoginScreenViewEvent
     data class TextEmailChanged(val changedTo: String) : LoginScreenViewEvent
     data class TextPassChanged(val changedTo: String) : LoginScreenViewEvent
 }
@@ -14,5 +15,6 @@ sealed interface LoginScreenViewEvent : ViewEvent {
 data class LoginScreenViewState(
     val buttonsEnabled: Boolean,
     val textEmail: String,
-    val textPass: String
+    val textPass: String,
+    val isHidden: Boolean,
 ) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreenViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreenViewModel.kt
@@ -25,6 +25,7 @@ class LoginScreenViewModel @Inject constructor(
         pushState(
             LoginScreenViewState(
                 buttonsEnabled = true,
+                isHidden = false,
                 textEmail = String(),
                 textPass = String()
             )
@@ -38,6 +39,7 @@ class LoginScreenViewModel @Inject constructor(
             is ClickedRegister -> onClickedRegister()
             is TextEmailChanged -> onTextEmailChanged(event)
             is TextPassChanged -> onTextPassChanged(event)
+            is ClickedShowPassword -> onShowPasswordClicked()
         }
     }
 
@@ -66,6 +68,12 @@ class LoginScreenViewModel @Inject constructor(
 
     private fun onClickedRegister() {
         routeTo(NavigateRegister)
+    }
+
+    private fun onShowPasswordClicked() {
+        lastPushedState?.run {
+            copy(isHidden = !isHidden)
+        }?.push()
     }
 
     private fun onTextEmailChanged(event: TextEmailChanged) {

--- a/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreen.kt
@@ -1,59 +1,74 @@
 package com.dodo.flashcards.presentation.registerScreen
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.Button
-import androidx.compose.material.Text
-import androidx.compose.material.TextField
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import com.dodo.flashcards.R
 import com.dodo.flashcards.presentation.registerScreen.RegisterScreenViewEvent.*
+import com.dodo.flashcards.presentation.registerScreen.composables.CustomOutlinedTextField
+import com.dodo.flashcards.presentation.registerScreen.composables.PasswordTextField
+import com.dodo.flashcards.presentation.theme.DarkColors
+
 
 @Composable
 fun RegisterScreen(viewModel: RegisterScreenViewModel) {
     viewModel.viewState.collectAsState().value?.apply {
         // Todo, clean up UI
         Column(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colors.primary)
+                .drawBehind {
+                    val path = Path()
+                    path.moveTo(0f, size.height * 0.05f)
+                    path.lineTo(size.width, 0.2f * size.height)
+                    path.lineTo(size.width, 0.95f * size.height)
+                    path.lineTo(0f, 0.8f * size.height)
+
+                    drawPath(
+                        path = path,
+                        color = DarkColors.background
+                    )
+                },
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            Text("USERNAME") // Todo, remove this with polish
-            TextField(
+            CustomOutlinedTextField(
                 value = textUsername,
                 onValueChange = {
                     viewModel.onEvent(TextUsernameChanged(changedTo = it))
                 },
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Text
-                )
+                label = stringResource(id = R.string.general_username_label),
+                keyboardType = KeyboardType.Text
             )
-            Text("EMAIL") // Todo, remove this with polish
-            TextField(
+            CustomOutlinedTextField(
                 value = textEmail,
                 onValueChange = {
                     viewModel.onEvent(TextEmailChanged(changedTo = it))
                 },
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Email
-                )
+                label = stringResource(R.string.general_email_label),
+                placeholderText = stringResource(R.string.general_placeholder_email_text),
+                keyboardType = KeyboardType.Email
             )
-            Text("PASSWORD") // Todo, remove this with polish
-            TextField(
+            PasswordTextField(
                 value = textPass,
                 onValueChange = {
                     viewModel.onEvent(TextPassChanged(changedTo = it))
                 },
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Password
-                )
+                label = stringResource(R.string.general_password_label),
+                keyboardType = KeyboardType.Password,
+                onIconChanged = {
+                    viewModel.onEvent(ClickedShowPassword)
+                },
+                isHidden = hidePassword
             )
             Button(
                 enabled = buttonsEnabled,
@@ -64,5 +79,6 @@ fun RegisterScreen(viewModel: RegisterScreenViewModel) {
                 Text(text = stringResource(R.string.register_register_button))
             }
         }
+
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreenModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreenModels.kt
@@ -1,5 +1,6 @@
 package com.dodo.flashcards.presentation.registerScreen
 
+import androidx.compose.ui.graphics.vector.ImageVector
 import com.dodo.flashcards.architecture.ViewEvent
 import com.dodo.flashcards.architecture.ViewState
 
@@ -8,11 +9,13 @@ sealed interface RegisterScreenViewEvent : ViewEvent {
     data class TextEmailChanged(val changedTo: String) : RegisterScreenViewEvent
     data class TextPassChanged(val changedTo: String) : RegisterScreenViewEvent
     data class TextUsernameChanged(val changedTo: String) : RegisterScreenViewEvent
+    object ClickedShowPassword : RegisterScreenViewEvent
 }
 
 data class RegisterScreenViewState(
     val buttonsEnabled: Boolean,
     val textEmail: String,
     val textPass: String,
-    val textUsername: String
+    val textUsername: String,
+    val hidePassword: Boolean,
 ) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreenViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreenViewModel.kt
@@ -23,6 +23,7 @@ class RegisterScreenViewModel @Inject constructor(
         pushState(
             RegisterScreenViewState(
                 buttonsEnabled = true,
+                hidePassword = false,
                 textEmail = String(),
                 textPass = String(),
                 textUsername = String()
@@ -36,6 +37,7 @@ class RegisterScreenViewModel @Inject constructor(
             is TextEmailChanged -> onTextEmailChanged(event)
             is TextPassChanged -> onTextPassChanged(event)
             is TextUsernameChanged -> onTextUsernameChanged(event)
+            is ClickedShowPassword -> onShowPasswordClicked()
         }
     }
 
@@ -59,7 +61,6 @@ class RegisterScreenViewModel @Inject constructor(
 
     private fun onTextEmailChanged(event: TextEmailChanged) {
         lastPushedState?.copy(textEmail = event.changedTo)?.push()
-
     }
 
     private fun onTextPassChanged(event: TextPassChanged) {
@@ -68,6 +69,12 @@ class RegisterScreenViewModel @Inject constructor(
 
     private fun onTextUsernameChanged(event: TextUsernameChanged) {
         lastPushedState?.copy(textUsername = event.changedTo)?.push()
+    }
+
+    private fun onShowPasswordClicked() {
+        lastPushedState?.run {
+            copy(hidePassword = !hidePassword)
+        }?.push()
     }
 
     private inline fun withLastState(block: RegisterScreenViewState.() -> Unit) {

--- a/app/src/main/java/com/dodo/flashcards/presentation/theme/Color.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/theme/Color.kt
@@ -1,8 +1,22 @@
 package com.dodo.flashcards.presentation.theme
 
+import androidx.compose.material.darkColors
 import androidx.compose.ui.graphics.Color
 
 val Purple200 = Color(0xFFBB86FC)
 val Purple500 = Color(0xFF6200EE)
 val Purple700 = Color(0xFF3700B3)
 val Teal200 = Color(0xFF03DAC5)
+
+val DarkColors = darkColors(
+    primary = Color(0xFFb0bec5),
+    primaryVariant = Color(0xff808e95),
+    secondary = Color(0xff91bcb4),
+    secondaryVariant = Color(0xff628c84),
+    onPrimary = Color.Black,
+    onSecondary = Color.Black,
+    background = Color(0xffe2f1f8),
+    surface = Color(0xFFe0f2f1),
+    onBackground = Color.Black,
+    onSurface = Color.Black
+)

--- a/app/src/main/java/com/dodo/flashcards/presentation/theme/Shape.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/theme/Shape.kt
@@ -2,10 +2,21 @@ package com.dodo.flashcards.presentation.theme
 
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Shapes
+import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.unit.dp
+
+data class CustomShapes(
+    val topRoundedCornerShape: RoundedCornerShape,
+    val bottomRoundedCornerShape: RoundedCornerShape
+)
 
 val Shapes = Shapes(
     small = RoundedCornerShape(4.dp),
     medium = RoundedCornerShape(4.dp),
-    large = RoundedCornerShape(0.dp)
+
+    //TODO move this to a custom shape class when we figure that out
+    large = RoundedCornerShape(
+        topStart = 30.dp,
+        topEnd = 30.dp,
+    ),
 )

--- a/app/src/main/java/com/dodo/flashcards/presentation/theme/Theme.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/theme/Theme.kt
@@ -6,11 +6,7 @@ import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 
-private val DarkColorPalette = darkColors(
-    primary = Purple200,
-    primaryVariant = Purple700,
-    secondary = Teal200
-)
+private val DarkColorPalette = DarkColors
 
 private val LightColorPalette = lightColors(
     primary = Purple500,

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
@@ -1,35 +1,71 @@
 package com.dodo.flashcards.presentation.welcomeScreen
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.Button
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.dodo.flashcards.R
+import com.dodo.flashcards.presentation.theme.DarkColors
 import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewEvent.*
 
 @Composable
 fun WelcomeScreen(viewModel: WelcomeScreenViewModel) {
     viewModel.viewState.collectAsState().value?.apply {
         Column(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colors.primary)
+                .drawBehind {
+                    val path = Path()
+                    path.moveTo(0f, size.height * 0.05f)
+                    path.lineTo(size.width, 0.2f * size.height)
+                    path.lineTo(size.width, 0.95f * size.height)
+                    path.lineTo(0f, 0.8f * size.height)
+
+                    drawPath(
+                        path = path,
+                        color = DarkColors.background
+                    )
+                },
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            Text(
-                text = username?.let {
-                    stringResource(R.string.welcome_message_username, it)
-                } ?: stringResource(R.string.welcome_error_username)
-            )
-            Button(onClick = {
-                viewModel.onEventDebounced(ClickedLogout)
-            }) {
-                Text(text = stringResource(R.string.welcome_logout_button))
+            Card(
+                modifier = Modifier.fillMaxSize(0.7f),
+                backgroundColor = MaterialTheme.colors.surface,
+                elevation = 6.dp
+
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = username?.let {
+                            stringResource(R.string.welcome_message_username, it)
+                        } ?: stringResource(R.string.welcome_error_username)
+                    )
+                    Button(onClick = {
+                        viewModel.onEventDebounced(ClickedLogout)
+                    }) {
+                        Text(text = stringResource(R.string.welcome_logout_button))
+                    }
+
+                }
             }
             Button(onClick = {
                 viewModel.onEventDebounced(ClickedEditProfile)

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="primary">#FFb0bec5</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,4 +36,23 @@
     </string>
     <!-- Text shown on button which will return user back to the Login screen -->
     <string name="forgot_pass_return_button">Return</string>
+
+    <!-- Text to show example email within textfield -->
+    <string name="general_placeholder_email_text">example@email.com</string>
+
+    <!-- Email label for email textfields -->
+    <string name="general_email_label">Email</string>
+
+    <!-- Email label for username textfields -->
+    <string name="general_username_label">Username</string>
+
+    <!-- Password label for username textfields -->
+    <string name="general_password_label">Password</string>
+
+    <!-- Placeholder string for content descriptions -->
+    <string name="content_description_placeholder">Content description</string>
+
+
+    <!-- Content description for password visbility toggle -->
+    <string name="password_visibility_description">Toggle password</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,6 +2,6 @@
 <resources>
 
     <style name="Theme.FlashcardsApp" parent="android:Theme.Material.Light.NoActionBar">
-        <item name="android:statusBarColor">@color/purple_700</item>
+        <item name="android:statusBarColor">@color/primary</item>
     </style>
 </resources>


### PR DESCRIPTION
## Background
UI in `LoginScreen`, `RegisterScreen`, and `WelcomeScreen` was in a crude state and needed styling before the end of sprint 1.  This commit implements the first iteration of a custom color scheme, as well as implementing a more aesthetic UI for all three screens.

## Changes
* Added canvas backgrounds utilizing drawPath for styling on all 3 screens.
* Implemented custom outlined text fields, one of which features a toggleable password visibility button.
* Stubbed out view events in `RegisterScreen` and `LoginScreen` for password visibility toggle - no actual visibility toggle functionality as of now.
* Added a custom color scheme that is currently under dark color scheme, should probably be switched to light. 

## Sample Image
<img src="https://user-images.githubusercontent.com/97764140/195967100-68835284-dfcb-41a4-beec-d7ae18c2382a.png" width="300px">