### PR TITLE
style: Update login & welcome screen UI | #33 #48

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/presentation/common/CustomOutlinedTextFields.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/common/CustomOutlinedTextFields.kt
@@ -1,7 +1,5 @@
-package com.dodo.flashcards.presentation.registerScreen.composables
+package com.dodo.flashcards.presentation.common
 
-import android.media.Image
-import android.text.BoringLayout
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -11,13 +9,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.constraintlayout.widget.Placeholder
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import com.dodo.flashcards.R
-import com.dodo.flashcards.architecture.EventReceiver
-import com.dodo.flashcards.presentation.registerScreen.RegisterScreenViewEvent
 
 @Composable
 fun CustomOutlinedTextField(
@@ -50,7 +46,7 @@ fun PasswordTextField(
     placeholderText: String = String(),
     keyboardType: KeyboardType,
     onIconChanged: () -> Unit,
-    isHidden: Boolean,
+    passHidden: Boolean,
 ) {
     OutlinedTextField(
         value = value,
@@ -67,9 +63,11 @@ fun PasswordTextField(
         trailingIcon = {
             IconButton(onClick = onIconChanged) {
                 Icon(
-                    imageVector = if (isHidden) Icons.Outlined.Visibility else Icons.Outlined.VisibilityOff,
+                    imageVector = if (!passHidden) Icons.Outlined.Visibility else Icons.Outlined.VisibilityOff,
                     contentDescription = stringResource(R.string.password_visibility_description)
                 )
             }
-        })
+        },
+        visualTransformation = if (!passHidden) VisualTransformation.None else PasswordVisualTransformation()
+    )
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/common/ScreenBackground.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/common/ScreenBackground.kt
@@ -1,0 +1,44 @@
+package com.dodo.flashcards.presentation.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Path
+import com.dodo.flashcards.presentation.theme.DarkColors
+
+@Composable
+fun ScreenBackground(
+    content: @Composable () -> Unit
+) {
+    val backgroundColor = MaterialTheme.colors.background
+    val surfaceColor = MaterialTheme.colors.surface
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(surfaceColor)
+            .drawBehind {
+                val path = Path().apply {
+                    moveTo(0f, size.height * 0.05f)
+                    lineTo(size.width, 0.2f * size.height)
+                    lineTo(size.width, 0.95f * size.height)
+                    lineTo(0f, 0.8f * size.height)
+                }
+                drawPath(
+                    path = path,
+                    color = backgroundColor
+                )
+            },
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassScreen.kt
@@ -17,10 +17,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.dodo.flashcards.R
 import com.dodo.flashcards.domain.models.AuthRepository
 import com.dodo.flashcards.domain.usecases.authentication.ForgotPassSendEmailUseCase
-import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewEvent.*
-import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.PendingConfirmation
-import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.InputEmail
-import com.dodo.flashcards.presentation.forgotPass.ForgotPassViewState.InvalidEmail
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewEvent.*
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.PendingConfirmation
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.InputEmail
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.InvalidEmail
 
 @Composable
 fun ForgotPassScreen(viewModel: ForgotPassViewModel) {

--- a/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreen.kt
@@ -1,91 +1,102 @@
 package com.dodo.flashcards.presentation.loginScreen
 
-import android.graphics.Color
-import android.graphics.Paint
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import com.dodo.flashcards.R
+import com.dodo.flashcards.presentation.common.ScreenBackground
 import com.dodo.flashcards.presentation.loginScreen.LoginScreenViewEvent.*
-import com.dodo.flashcards.presentation.registerScreen.composables.CustomOutlinedTextField
-import com.dodo.flashcards.presentation.registerScreen.composables.PasswordTextField
-import com.dodo.flashcards.presentation.theme.DarkColors
+import com.dodo.flashcards.presentation.common.CustomOutlinedTextField
+import com.dodo.flashcards.presentation.common.PasswordTextField
+import com.dodo.flashcards.presentation.theme.Typography
 
 @Composable
 fun LoginScreen(viewModel: LoginScreenViewModel) {
-    viewModel.viewState.collectAsState().value?.apply {
-        // Todo, clean up UI
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colors.primary)
-                .drawBehind {
-                    val path = Path()
-                    path.moveTo(0f, size.height * 0.05f)
-                    path.lineTo(size.width, 0.2f * size.height)
-                    path.lineTo(size.width, 0.95f * size.height)
-                    path.lineTo(0f, 0.8f * size.height)
-
-                    drawPath(
-                        path = path,
-                        color = DarkColors.background
-                    )
-                },
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
-        ) {
-            Text(text = stringResource(id = R.string.app_name))
-            CustomOutlinedTextField(
-                value = textEmail,
-                onValueChange = { viewModel.onEvent(TextEmailChanged(it)) },
-                label = stringResource(R.string.general_email_label),
-                keyboardType = KeyboardType.Email,
-            )
-            PasswordTextField(
-                value = textPass,
-                onValueChange = { viewModel.onEvent(TextPassChanged(it)) },
-                label = stringResource(R.string.general_password_label),
-                keyboardType = KeyboardType.Password,
-                onIconChanged = {
-                    viewModel.onEvent(ClickedShowPassword)
-                },
-                isHidden = isHidden,
-            )
-
-            Button(
-                enabled = buttonsEnabled,
-                onClick = {
-                    viewModel.onEventDebounced(ClickedLogin)
-                }
+    ScreenBackground {
+        viewModel.viewState.collectAsState().value?.apply {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Text(text = stringResource(R.string.login_login_button))
-            }
-            OutlinedButton(
-                enabled = buttonsEnabled,
-                onClick = {
-                    viewModel.onEventDebounced(ClickedRegister)
-                }) {
-                Text(text = stringResource(R.string.login_register_button))
-            }
-            TextButton(
-                enabled = buttonsEnabled,
-                onClick = {
-                    viewModel.onEventDebounced(ClickedForgotPassword)
-                }) {
-                Text(text = stringResource(R.string.login_forgot_password_button))
+                Text(
+                    text = stringResource(id = R.string.app_name),
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    style = Typography.h6,
+                    color = MaterialTheme.colors.onBackground,
+                    textAlign = TextAlign.Center,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = stringResource(id = R.string.app_name_subtext),
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    style = Typography.subtitle1,
+                    color = MaterialTheme.colors.onBackground,
+                    textAlign = TextAlign.Center,
+                    fontWeight = FontWeight.Medium,
+                    fontStyle = FontStyle.Italic
+                )
+                CustomOutlinedTextField(
+                    value = textEmail,
+                    onValueChange = { viewModel.onEvent(TextEmailChanged(it)) },
+                    label = stringResource(R.string.general_email_label),
+                    keyboardType = KeyboardType.Email,
+                )
+                PasswordTextField(
+                    value = textPass,
+                    onValueChange = { viewModel.onEvent(TextPassChanged(it)) },
+                    label = stringResource(R.string.general_password_label),
+                    keyboardType = KeyboardType.Password,
+                    onIconChanged = {
+                        viewModel.onEvent(ClickedShowPassword)
+                    },
+                    passHidden = isHidden,
+                )
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Button(
+                        modifier = Modifier.defaultMinSize(
+                            minWidth = dimensionResource(id = R.dimen.min_width_button)
+                        ),
+                        enabled = buttonsEnabled,
+                        onClick = {
+                            viewModel.onEventDebounced(ClickedLogin)
+                        }
+                    ) {
+                        Text(text = stringResource(R.string.login_login_button))
+                    }
+                    OutlinedButton(
+                        modifier = Modifier.defaultMinSize(
+                            minWidth = dimensionResource(id = R.dimen.min_width_button)
+                        ),
+                        enabled = buttonsEnabled,
+                        onClick = {
+                            viewModel.onEventDebounced(ClickedRegister)
+                        }) {
+                        Text(text = stringResource(R.string.login_register_button))
+                    }
+                    TextButton(
+                        modifier = Modifier.defaultMinSize(
+                            minWidth = dimensionResource(id = R.dimen.min_width_button)
+                        ),
+                        enabled = buttonsEnabled,
+                        onClick = {
+                            viewModel.onEventDebounced(ClickedForgotPassword)
+                        }) {
+                        Text(text = stringResource(R.string.login_forgot_password_button))
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreen.kt
@@ -13,8 +13,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import com.dodo.flashcards.R
 import com.dodo.flashcards.presentation.registerScreen.RegisterScreenViewEvent.*
-import com.dodo.flashcards.presentation.registerScreen.composables.CustomOutlinedTextField
-import com.dodo.flashcards.presentation.registerScreen.composables.PasswordTextField
+import com.dodo.flashcards.presentation.common.CustomOutlinedTextField
+import com.dodo.flashcards.presentation.common.PasswordTextField
 import com.dodo.flashcards.presentation.theme.DarkColors
 
 
@@ -68,7 +68,7 @@ fun RegisterScreen(viewModel: RegisterScreenViewModel) {
                 onIconChanged = {
                     viewModel.onEvent(ClickedShowPassword)
                 },
-                isHidden = hidePassword
+                passHidden = hidePassword
             )
             Button(
                 enabled = buttonsEnabled,

--- a/app/src/main/java/com/dodo/flashcards/presentation/theme/Theme.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/theme/Theme.kt
@@ -5,22 +5,20 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 
 private val DarkColorPalette = DarkColors
 
 private val LightColorPalette = lightColors(
-    primary = Purple500,
-    primaryVariant = Purple700,
-    secondary = Teal200
-
-    /* Other default colors to override
-    background = Color.White,
-    surface = Color.White,
+    primary = Color(1, 87, 155),
+    primaryVariant = Color(0, 47, 108),
+    secondary = Color(206, 147, 216),
+    background = Color(239, 239, 236),
+    surface = Color(227, 227, 223),
     onPrimary = Color.White,
     onSecondary = Color.Black,
-    onBackground = Color.Black,
+    onBackground = Color(46, 46, 46),
     onSurface = Color.Black,
-    */
 )
 
 @Composable
@@ -28,14 +26,8 @@ fun FlashcardsAppTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    val colors = if (darkTheme) {
-        DarkColorPalette
-    } else {
-        LightColorPalette
-    }
-
     MaterialTheme(
-        colors = colors,
+        colors =  LightColorPalette,
         typography = Typography,
         shapes = Shapes,
         content = content

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
@@ -1,13 +1,8 @@
 package com.dodo.flashcards.presentation.welcomeScreen
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.Button
-import androidx.compose.material.Card
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
@@ -15,62 +10,55 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.dodo.flashcards.R
+import com.dodo.flashcards.presentation.common.ScreenBackground
 import com.dodo.flashcards.presentation.theme.DarkColors
+import com.dodo.flashcards.presentation.theme.Typography
 import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewEvent.*
 
 @Composable
 fun WelcomeScreen(viewModel: WelcomeScreenViewModel) {
-    viewModel.viewState.collectAsState().value?.apply {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colors.primary)
-                .drawBehind {
-                    val path = Path()
-                    path.moveTo(0f, size.height * 0.05f)
-                    path.lineTo(size.width, 0.2f * size.height)
-                    path.lineTo(size.width, 0.95f * size.height)
-                    path.lineTo(0f, 0.8f * size.height)
-
-                    drawPath(
-                        path = path,
-                        color = DarkColors.background
-                    )
-                },
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
-        ) {
-            Card(
-                modifier = Modifier.fillMaxSize(0.7f),
-                backgroundColor = MaterialTheme.colors.surface,
-                elevation = 6.dp
-
+    ScreenBackground {
+        viewModel.viewState.collectAsState().value?.apply {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                Column(
-                    modifier = Modifier.fillMaxSize(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center
-                ) {
-                    Text(
-                        text = username?.let {
-                            stringResource(R.string.welcome_message_username, it)
-                        } ?: stringResource(R.string.welcome_error_username)
-                    )
-                    Button(onClick = {
-                        viewModel.onEventDebounced(ClickedLogout)
-                    }) {
+                Text(
+                    text = username?.let {
+                        stringResource(R.string.welcome_message_username, it)
+                    } ?: stringResource(R.string.welcome_error_username),
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    style = Typography.h6,
+                    color = MaterialTheme.colors.onBackground,
+                    textAlign = TextAlign.Center,
+                    fontWeight = FontWeight.Bold
+                )
+                Column {
+                    Button(
+                        modifier = Modifier.defaultMinSize(
+                            minWidth = dimensionResource(id = R.dimen.min_width_button)
+                        ),
+                        onClick = {
+                            viewModel.onEventDebounced(ClickedEditProfile)
+                        }) {
+                        Text(text = stringResource(R.string.welcome_edit_profile_button))
+                    }
+                    OutlinedButton(
+                        modifier = Modifier.defaultMinSize(
+                            minWidth = dimensionResource(id = R.dimen.min_width_button)
+                        ),
+                        onClick = {
+                            viewModel.onEventDebounced(ClickedLogout)
+                        }) {
                         Text(text = stringResource(R.string.welcome_logout_button))
                     }
-
                 }
-            }
-            Button(onClick = {
-                viewModel.onEventDebounced(ClickedEditProfile)
-            }) {
-                Text(text = "Edit Profile")
             }
         }
     }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,5 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="primary">#FFb0bec5</color>
+    <color name="primary">#FF01579b</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="min_width_button">128dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
-    <string name="app_name">FlashcardsApp</string>
+    <string name="app_name">Dodo</string>
+    <string name="app_name_subtext">a study tool… for dodos</string>
 
     <!-- Text shown on button which a user clicks on if they forgot their password -->
     <string name="login_forgot_password_button">Forgot Password?</string>
@@ -12,6 +13,7 @@
     <string name="register_register_button">Register</string>
 
     <!-- Text shown on button which will logout an authenticated user -->
+    <string name="welcome_edit_profile_button">Edit Profile</string>
     <string name="welcome_logout_button">Logout</string>
     <!-- Text shown when a user has logged in to welcome them by their username -->
     <string name="welcome_message_username">Welcome %s</string>


### PR DESCRIPTION
style: Update login & welcome screen UI | #33 #48

* Continue Joe's work to touch-up the login & welcome screens explicitly.
* Add function to the password hide/show implementation.
* Change colors slightly to a blue, though still placeholder.
* Encapsulate the column screen background stuff as a `ScreenBackground` composable.

<img width="300px" src="https://user-images.githubusercontent.com/77797048/195997535-a07e6548-b783-48da-b6fc-2ca747c798c4.png">
