### PR TITLE
style: Clean up forgot password and edit profile screens | #49

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
@@ -75,6 +75,11 @@ class MainActivity : ComponentActivity(), Router<MainDestination> {
                     inclusive = true
                 }
             }
+            if (navController.currentDestination?.route == ForgotPass.route) {
+                popUpTo(route = Login.route) {
+                    inclusive = true
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/EditProfileScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/EditProfileScreen.kt
@@ -1,34 +1,67 @@
 package com.dodo.flashcards.presentation.editProfileScreen
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.dodo.flashcards.R
+import com.dodo.flashcards.presentation.common.ScreenBackground
 import com.dodo.flashcards.presentation.editProfileScreen.EditProfileViewEvent.*
+import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsername.EditUsernameViewEvent
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewEvent
+import com.dodo.flashcards.presentation.loginScreen.LoginScreenViewEvent
+import com.dodo.flashcards.presentation.theme.Typography
 
 @Composable
 fun EditProfileScreen(viewModel: EditProfileViewModel) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
+    ScreenBackground {
         viewModel.viewState.collectAsState().value?.apply {
-            Text(text = "Edit Profile")
-            TextButton(onClick = { viewModel.onEventDebounced(ClickedEditUsername) }) {
-                Text("Edit Username")
-            }
-            TextButton(onClick = { viewModel.onEventDebounced(ClickedEditPassword) }) {
-                Text("Edit Password")
-            }
-            Button(onClick = { viewModel.onEventDebounced(ClickedReturn) }) {
-                Text("Return")
+            Text(
+                text = "Edit Profile",
+                modifier = Modifier.padding(horizontal = 16.dp),
+                style = Typography.h6,
+                color = MaterialTheme.colors.onBackground,
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Bold
+            )
+            Column {
+                TextButton(
+                    modifier = Modifier.defaultMinSize(
+                        minWidth = dimensionResource(id = R.dimen.min_width_button)
+                    ),
+                    onClick = {
+                        viewModel.onEventDebounced(ClickedEditUsername)
+                    }) {
+                    Text(text = "Edit Username")
+                }
+                TextButton(
+                    modifier = Modifier.defaultMinSize(
+                        minWidth = dimensionResource(id = R.dimen.min_width_button)
+                    ),
+                    onClick = {
+                        viewModel.onEventDebounced(ClickedEditPassword)
+                    }) {
+                    Text(text = "Edit Password")
+                }
+                TextButton(
+                    modifier = Modifier.defaultMinSize(
+                        minWidth = dimensionResource(id = R.dimen.min_width_button)
+                    ),
+                    onClick = {
+                        viewModel.onEventDebounced(ClickedReturn)
+                    }) {
+                    Text("Return")
+                }
             }
         }
     }

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassModels.kt
@@ -6,6 +6,8 @@ import com.dodo.flashcards.architecture.ViewState
 sealed interface EditPassViewEvent : ViewEvent {
     object ClickedConfirm : EditPassViewEvent
     object ClickedReturn : EditPassViewEvent
+    object ClickedShowPasswordOld : EditPassViewEvent
+    object ClickedShowPasswordNew : EditPassViewEvent
     data class TextPassNewChanged(val changedTo: String) : EditPassViewEvent
     data class TextPassOldChanged(val changedTo: String) : EditPassViewEvent
 }
@@ -13,6 +15,8 @@ sealed interface EditPassViewEvent : ViewEvent {
 data class EditPassViewState(
     val confirmButtonEnabled: Boolean,
     val hasSuccessfullySet: Boolean,
+    val passHiddenOld: Boolean,
+    val passHiddenNew: Boolean,
     val textPassNew: String,
     val textPassOld: String
 ) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassScreen.kt
@@ -1,60 +1,129 @@
 package com.dodo.flashcards.presentation.editProfileScreen.subscreens.editPass
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.dodo.flashcards.R
+import com.dodo.flashcards.presentation.common.PasswordTextField
+import com.dodo.flashcards.presentation.common.ScreenBackground
 import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editPass.EditPassViewEvent.*
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewEvent
+import com.dodo.flashcards.presentation.registerScreen.RegisterScreenViewEvent
+import com.dodo.flashcards.presentation.theme.Typography
 
 @Composable
 fun EditPassScreen(viewModel: EditPassViewModel) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
+    ScreenBackground {
         viewModel.viewState.collectAsState().value?.apply {
-            Text("Edit Pass")
-            Text("For security, enter your old password")
-            TextField(
-                value = textPassOld,
-                onValueChange = {
-                    viewModel.onEvent(TextPassOldChanged(it))
-                }
-            )
-            Text("Enter a new password")
-            Text("A password must be at least 6 characters")
-            TextField(
-                value = textPassNew,
-                onValueChange = {
-                    viewModel.onEvent(TextPassNewChanged(it))
-                },
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Password
-                )
-            )
             if (hasSuccessfullySet) {
-                Text("Successful update")
-            }
-            Button(
-                enabled = confirmButtonEnabled,
-                onClick = {
-                    viewModel.onEventDebounced(ClickedConfirm)
+                Text(
+                    text = "Changed Password",
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    style = Typography.h6,
+                    color = MaterialTheme.colors.onBackground,
+                    textAlign = TextAlign.Center,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    modifier =
+                    Modifier
+                        .padding(horizontal = 16.dp)
+                        .fillMaxWidth(0.9f),
+                    style = Typography.subtitle2,
+                    color = MaterialTheme.colors.onBackground,
+                    textAlign = TextAlign.Center,
+                    text = "Your password has been successfully changed."
+                )
+                Button(onClick = {
+                    viewModel.onEventDebounced(ClickedReturn)
                 }) {
-                Text("Confirm")
-            }
-            Button(onClick = {
-                viewModel.onEventDebounced(ClickedReturn)
-            }) {
-                Text("Return")
+                    Text(stringResource(R.string.forgot_pass_return_button))
+                }
+            } else {
+                Text(
+                    text = "Edit Password",
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    style = Typography.h6,
+                    color = MaterialTheme.colors.onBackground,
+                    textAlign = TextAlign.Center,
+                    fontWeight = FontWeight.Bold
+                )
+                PasswordTextField(
+                    value = textPassOld,
+                    onValueChange = {
+                        viewModel.onEvent(
+                            TextPassOldChanged(it)
+                        )
+                    },
+                    label = "Old Password",
+                    keyboardType = KeyboardType.Password,
+                    onIconChanged = {
+                        viewModel.onEvent(ClickedShowPasswordOld)
+                    },
+                    passHidden = passHiddenOld
+                )
+                Text(
+                    modifier =
+                    Modifier
+                        .padding(horizontal = 16.dp)
+                        .fillMaxWidth(0.9f),
+                    style = Typography.subtitle2,
+                    color = MaterialTheme.colors.onBackground,
+                    textAlign = TextAlign.Center,
+                    text = "For your security, enter your previous password."
+                )
+                PasswordTextField(
+                    value = textPassNew,
+                    onValueChange = {
+                        viewModel.onEvent(
+                            TextPassNewChanged(it)
+                        )
+                    },
+                    label = "New Password",
+                    keyboardType = KeyboardType.Password,
+                    onIconChanged = {
+                        viewModel.onEvent(ClickedShowPasswordNew)
+                    },
+                    passHidden = passHiddenNew
+                )
+                Text(
+                    modifier =
+                    Modifier
+                        .padding(horizontal = 16.dp)
+                        .fillMaxWidth(0.9f),
+                    style = Typography.subtitle2,
+                    color = MaterialTheme.colors.onBackground,
+                    textAlign = TextAlign.Center,
+                    text = stringResource(R.string.register_register_password_subtext)
+                )
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Button(
+                        enabled = confirmButtonEnabled,
+                        onClick = {
+                            viewModel.onEventDebounced(ClickedConfirm)
+                        }) {
+                        Text("Confirm")
+                    }
+                    Button(onClick = {
+                        viewModel.onEventDebounced(ClickedReturn)
+                    }) {
+                        Text("Return")
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassViewModel.kt
@@ -27,7 +27,9 @@ class EditPassViewModel @Inject constructor(
                 confirmButtonEnabled = false,
                 hasSuccessfullySet = false,
                 textPassNew = String(),
-                textPassOld = String()
+                textPassOld = String(),
+                passHiddenOld = false,
+                passHiddenNew = false
             )
         )
     }
@@ -36,6 +38,8 @@ class EditPassViewModel @Inject constructor(
         when (event) {
             is ClickedConfirm -> onClickedConfirm()
             is ClickedReturn -> onClickedReturn()
+            is ClickedShowPasswordOld -> onClickedShowPasswordOld()
+            is ClickedShowPasswordNew -> onClickedShowPasswordNew()
             is TextPassNewChanged -> onTextPassNewChanged(event)
             is TextPassOldChanged -> onTextPassOldChanged(event)
         }
@@ -70,6 +74,14 @@ class EditPassViewModel @Inject constructor(
 
     private fun onClickedReturn() {
         routeTo(NavigateUp)
+    }
+
+    private fun onClickedShowPasswordOld() {
+
+    }
+
+    private fun onClickedShowPasswordNew() {
+
     }
 
     private fun onTextPassNewChanged(event: TextPassNewChanged) {

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameScreen.kt
@@ -1,46 +1,76 @@
 package com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsername
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.Button
-import androidx.compose.material.Text
-import androidx.compose.material.TextField
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.dodo.flashcards.R
+import com.dodo.flashcards.presentation.common.CustomOutlinedTextField
+import com.dodo.flashcards.presentation.common.ScreenBackground
+import com.dodo.flashcards.presentation.editProfileScreen.EditProfileViewEvent
 import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsername.EditUsernameViewEvent.*
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewEvent
+import com.dodo.flashcards.presentation.theme.Typography
+import com.dodo.flashcards.util.Screen
 
 @Composable
 fun EditUsernameScreen(viewModel: EditUsernameViewModel) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
+    ScreenBackground {
         viewModel.viewState.collectAsState().value?.apply {
-            Text("Edit Username")
-            TextField(
+            Text(
+                text = "Edit Username",
+                modifier = Modifier.padding(horizontal = 16.dp),
+                style = Typography.h6,
+                color = MaterialTheme.colors.onBackground,
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Bold
+            )
+            CustomOutlinedTextField(
                 value = textUsername,
                 onValueChange = {
                     viewModel.onEvent(TextUsernameChanged(it))
-                }
+                },
+                label = stringResource(id = R.string.general_username_label),
+                keyboardType = KeyboardType.Text
             )
-            if (hasSuccessfullySet) {
-                Text("Successful update")
-            }
-            Button(
-                enabled = confirmButtonEnabled,
-                onClick = {
-                    viewModel.onEventDebounced(ClickedConfirm)
-                }) {
-                Text("Confirm")
-            }
-            Button(onClick = {
-                viewModel.onEventDebounced(ClickedReturn)
-            }) {
-                Text("Return")
+            Text(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .fillMaxWidth(0.9f),
+                style = Typography.subtitle2,
+                color = MaterialTheme.colors.onBackground,
+                textAlign = TextAlign.Center,
+                text = stringResource(R.string.register_register_username_subtext)
+            )
+            Column {
+                Button(
+                    modifier = Modifier.defaultMinSize(
+                        minWidth = dimensionResource(id = R.dimen.min_width_button)
+                    ),
+                    //   enabled = buttonsEnabled,
+                    onClick = {
+                        viewModel.onEventDebounced(ClickedConfirm)
+                    }
+                ) {
+                    Text(text = "Confirm")
+                }
+                TextButton(
+                    modifier = Modifier.defaultMinSize(
+                        minWidth = dimensionResource(id = R.dimen.min_width_button)
+                    ),
+                    onClick = {
+                        viewModel.onEventDebounced(ClickedReturn)
+                    }) {
+                    Text("Return")
+                }
             }
         }
     }

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotError.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotError.kt
@@ -1,0 +1,57 @@
+package com.dodo.flashcards.presentation.forgotPassScreen
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.dodo.flashcards.R
+import com.dodo.flashcards.architecture.EventReceiver
+import com.dodo.flashcards.presentation.theme.Typography
+
+@Composable
+fun ForgotError(
+    email: String,
+    eventReceiver: EventReceiver<ForgotPassViewEvent>
+) {
+    val placeholderStrIndex = stringResource(R.string.forgot_pass_invalid_email).indexOf("%s")
+    Text(
+        text = stringResource(id = R.string.forgot_pass_error_header),
+        modifier = Modifier.padding(horizontal = 16.dp),
+        style = Typography.h6,
+        color = MaterialTheme.colors.onBackground,
+        textAlign = TextAlign.Center,
+        fontWeight = FontWeight.Bold
+    )
+    Text(
+        modifier =
+        Modifier
+            .padding(horizontal = 16.dp)
+            .fillMaxWidth(0.9f),
+        style = Typography.subtitle2,
+        color = MaterialTheme.colors.onBackground,
+        textAlign = TextAlign.Center,
+        text = AnnotatedString(
+            text = stringResource(R.string.forgot_pass_invalid_email, email),
+            spanStyles = listOf(
+                AnnotatedString.Range(
+                    SpanStyle(fontWeight = FontWeight.Bold),
+                    placeholderStrIndex,
+                    placeholderStrIndex + email.length
+                )
+            )
+        )
+    )
+    Button(onClick = { eventReceiver.onEventDebounced(ForgotPassViewEvent.ClickedReturn) }) {
+        Text(stringResource(R.string.forgot_pass_return_button))
+    }
+
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotIdle.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotIdle.kt
@@ -1,0 +1,65 @@
+package com.dodo.flashcards.presentation.forgotPassScreen
+
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.dodo.flashcards.R
+import com.dodo.flashcards.architecture.EventReceiver
+import com.dodo.flashcards.presentation.common.CustomOutlinedTextField
+import com.dodo.flashcards.presentation.registerScreen.RegisterScreenViewEvent
+import com.dodo.flashcards.presentation.theme.Typography
+
+@Composable
+fun ForgotIdle(
+    textEmail: String,
+    eventReceiver: EventReceiver<ForgotPassViewEvent>
+) {
+    Text(
+        text = stringResource(id = R.string.forgot_pass_header),
+        modifier = Modifier.padding(horizontal = 16.dp),
+        style = Typography.h6,
+        color = MaterialTheme.colors.onBackground,
+        textAlign = TextAlign.Center,
+        fontWeight = FontWeight.Bold
+    )
+    Text(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .fillMaxWidth(0.9f),
+        style = Typography.subtitle2,
+        color = MaterialTheme.colors.onBackground,
+        textAlign = TextAlign.Center,
+        text = stringResource(id = R.string.forgot_pass_prompt)
+    )
+    CustomOutlinedTextField(
+        value = textEmail,
+        onValueChange = {
+            eventReceiver.onEvent(ForgotPassViewEvent.TextChangedEmail(it))
+        },
+        label = stringResource(id = R.string.general_email_label),
+        keyboardType = KeyboardType.Text
+    )
+    Button(
+        modifier = Modifier.defaultMinSize(
+            minWidth = dimensionResource(id = R.dimen.min_width_button)
+        ),
+        //   enabled = buttonsEnabled,
+        onClick = {
+            eventReceiver.onEventDebounced(ForgotPassViewEvent.ClickedConfirmEmail)
+        }
+    ) {
+        Text(text = stringResource(id = R.string.forgot_pass_email_button))
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassModels.kt
@@ -14,5 +14,6 @@ sealed interface ForgotPassViewState : ViewState {
 
     data class InputEmail(override val textEmail: String) : ForgotPassViewState
     data class InvalidEmail(override val textEmail: String) : ForgotPassViewState
+    data class Loading(override val textEmail: String) : ForgotPassViewState
     data class PendingConfirmation(override val textEmail: String) : ForgotPassViewState
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassScreen.kt
@@ -1,63 +1,37 @@
 package com.dodo.flashcards.presentation.forgotPassScreen
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.Button
-import androidx.compose.material.Text
-import androidx.compose.material.TextField
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import com.dodo.flashcards.R
-import com.dodo.flashcards.domain.models.AuthRepository
-import com.dodo.flashcards.domain.usecases.authentication.ForgotPassSendEmailUseCase
+import com.dodo.flashcards.presentation.common.ScreenBackground
 import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewEvent.*
-import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.PendingConfirmation
-import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.InputEmail
-import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.InvalidEmail
+import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewState.*
+import com.dodo.flashcards.presentation.theme.Typography
 
 @Composable
 fun ForgotPassScreen(viewModel: ForgotPassViewModel) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
+    ScreenBackground {
         viewModel.viewState.collectAsState().value?.apply {
             when (this) {
-                is InputEmail -> {
-                    Text(stringResource(id = R.string.forgot_pass_prompt))
-                    TextField(
-                        value = textEmail,
-                        onValueChange = {
-                            viewModel.onEvent(TextChangedEmail(it))
-                        },
-                        keyboardOptions = KeyboardOptions(
-                            keyboardType = KeyboardType.Email
-                        )
-                    )
-                    Button(onClick = { viewModel.onEventDebounced(ClickedConfirmEmail) }) {
-                        Text(stringResource(id = R.string.forgot_pass_email_button))
-                    }
-                }
-                is InvalidEmail -> {
-                    Text(stringResource(id = R.string.forgot_pass_invalid_email, textEmail))
-                    Button(onClick = { viewModel.onEventDebounced(ClickedReturn) }) {
-                        Text(stringResource(R.string.forgot_pass_return_button))
-                    }
-                }
-                is PendingConfirmation -> {
-                    Text(stringResource(id = R.string.forgot_pass_confirmation, textEmail))
-                    Button(onClick = { viewModel.onEventDebounced(ClickedReturn) }) {
-                        Text(stringResource(R.string.forgot_pass_return_button))
-                    }
-                }
+                is InputEmail -> ForgotIdle(
+                    textEmail = textEmail,
+                    eventReceiver = viewModel
+                )
+                is InvalidEmail -> ForgotError(
+                    email = textEmail,
+                    eventReceiver = viewModel
+                )
+                is Loading -> CircularProgressIndicator()
+                is PendingConfirmation -> ForgotSuccess(textEmail, viewModel)
             }
         }
     }

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotPassViewModel.kt
@@ -34,6 +34,7 @@ class ForgotPassViewModel @Inject constructor(
     private fun onClickedConfirmEmail() {
         viewModelScope.launch(Dispatchers.IO) {
             lastPushedState?.apply {
+                Loading(textEmail).push()
                 forgotPassSendEmailUseCase(textEmail)
                     .doOnSuccess {
                         PendingConfirmation(textEmail).push()

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotSuccess.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotSuccess.kt
@@ -1,0 +1,59 @@
+package com.dodo.flashcards.presentation.forgotPassScreen
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.dodo.flashcards.R
+import com.dodo.flashcards.architecture.EventReceiver
+import com.dodo.flashcards.presentation.theme.Typography
+
+@Composable
+fun ForgotSuccess(
+    email: String,
+    eventReceiver: EventReceiver<ForgotPassViewEvent>
+) {
+    val placeholderStrIndex = stringResource(R.string.forgot_pass_confirmation).indexOf("%s")
+    Text(
+        text = stringResource(id = R.string.forgot_pass_success_header),
+        modifier = Modifier.padding(horizontal = 16.dp),
+        style = Typography.h6,
+        color = MaterialTheme.colors.onBackground,
+        textAlign = TextAlign.Center,
+        fontWeight = FontWeight.Bold
+    )
+    Text(
+        modifier =
+        Modifier
+            .padding(horizontal = 16.dp)
+            .fillMaxWidth(0.9f),
+        style = Typography.subtitle2,
+        color = MaterialTheme.colors.onBackground,
+        textAlign = TextAlign.Center,
+        text = AnnotatedString(
+            text = stringResource(R.string.forgot_pass_confirmation, email),
+            spanStyles = listOf(
+                AnnotatedString.Range(
+                    SpanStyle(fontWeight = FontWeight.Bold),
+                    placeholderStrIndex,
+                    placeholderStrIndex + email.length
+                )
+            )
+        )
+    )
+    Button(onClick = { eventReceiver.onEventDebounced(ForgotPassViewEvent.ClickedReturn) }) {
+        Text(stringResource(R.string.forgot_pass_return_button))
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreen.kt
@@ -28,7 +28,7 @@ fun LoginScreen(viewModel: LoginScreenViewModel) {
     ScreenBackground {
         viewModel.viewState.collectAsState().value?.apply {
             Text(
-                text = stringResource(id = R.string.register_register_header),
+                text = stringResource(id = R.string.app_name),
                 modifier = Modifier.padding(horizontal = 16.dp),
                 style = Typography.h6,
                 color = MaterialTheme.colors.onBackground,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="register_register_header">Create an Account</string>
     <!-- Text shown on button which will register a user -->
     <string name="register_register_button">Register</string>
-    <string name="register_continue_button">Continue</string>
+    <string name="register_continue_button">Continue to App</string>
     <string name="register_register_username_subtext">Username cannot contain special characters.</string>
     <string name="register_register_email_subtext">We\'ll never share your email with anyone else.</string>
     <string name="register_register_password_subtext">
@@ -22,10 +22,10 @@
         Email Verification
     </string>
     <string name="register_email_verification_prompt_1">
-        We sent an email to %s.
+        We sent an e-mail to %s.
     </string>
     <string name="register_email_verification_prompt_2">
-        Just click on the link in that email to complete your signup.
+        Just click on the link in that e-mail to optionally verify and complete your signup.
     </string>
     <!-- Text shown on button which will logout an authenticated user -->
     <string name="welcome_edit_profile_button">Edit Profile</string>
@@ -35,17 +35,20 @@
     <!-- Text shown when unable to correctly fetch a username for this user -->
     <string name="welcome_error_username">Unknown</string>
 
+    <string name="forgot_pass_header">Reset Password</string>
+    <string name="forgot_pass_error_header">Invalid E-mail</string>
+    <string name="forgot_pass_success_header">Check Your E-mail</string>
     <!-- Text shown on header prompting user to enter their email to reset password -->
     <string name="forgot_pass_prompt">
         Enter the e-mail address associated with your account.
     </string>
     <!-- Text shown on the button prompting user to use the email they have input to reset the password -->
     <string name="forgot_pass_email_button">
-        Send Password Reset E-mail
+        Continue
     </string>
     <!-- Text shown on the header after user has confirmed their e-mail for password reset -->
     <string name="forgot_pass_confirmation">
-        If %s is a registered account, an e-mail has been sent to reset your password.
+        We\'ve sent an e-mail to %s. To reset your password, click the link within the e-mail.
     </string>
     <!-- Text shown on the header after user has confirmed an invalid e-mail -->
     <string name="forgot_pass_invalid_email">


### PR DESCRIPTION
style: Clean up forgot password and edit profile screens | #49

* Apply new style to forgot password and edit profile related screens
* This is applied pretty narly, due to the time-crunch, needs a follow-up refactor commit.
* Updates edit profile subscreens as well.