### PR TITLE
refactor: Update custom text fields to use a type for code reuse | #33 #47 #49

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/presentation/common/CustomOutlinedTextFields.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/common/CustomOutlinedTextFields.kt
@@ -19,24 +19,24 @@ import com.dodo.flashcards.R
 
 @Composable
 fun CustomOutlinedTextField(
+    textFieldType: TextFieldType,
     value: String,
-    onValueChange: (String) -> Unit,
-    label: String,
-    placeholderText: String = String(),
-    keyboardType: KeyboardType,
+    onValueChange: (String) -> Unit
 ) {
     OutlinedTextField(
         modifier = Modifier.fillMaxWidth(0.9f),
         value = value,
         onValueChange = onValueChange,
         keyboardOptions = KeyboardOptions(
-            keyboardType = keyboardType
+            keyboardType = textFieldType.keyboardType
         ),
         label = {
-            Text(label)
+            Text(stringResource(textFieldType.labelResourceId))
         },
         placeholder = {
-            Text(placeholderText)
+            textFieldType.placeholderResourceId?.apply {
+                Text(stringResource(this))
+            }
         },
     )
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/common/TextFieldType.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/common/TextFieldType.kt
@@ -1,0 +1,21 @@
+package com.dodo.flashcards.presentation.common
+
+import androidx.annotation.StringRes
+import androidx.compose.ui.text.input.KeyboardType
+import com.dodo.flashcards.R
+
+enum class TextFieldType(
+    val keyboardType: KeyboardType,
+    @StringRes val labelResourceId: Int,
+    @StringRes val placeholderResourceId: Int? = null,
+) {
+    EMAIL(
+        keyboardType = KeyboardType.Email,
+        labelResourceId = R.string.general_email_label,
+        placeholderResourceId = R.string.general_placeholder_email_text
+    ),
+    USERNAME(
+        keyboardType = KeyboardType.Text,
+        labelResourceId = R.string.general_username_label,
+    );
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import com.dodo.flashcards.R
 import com.dodo.flashcards.presentation.common.CustomOutlinedTextField
 import com.dodo.flashcards.presentation.common.ScreenBackground
+import com.dodo.flashcards.presentation.common.TextFieldType
 import com.dodo.flashcards.presentation.editProfileScreen.EditProfileViewEvent
 import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsername.EditUsernameViewEvent.*
 import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewEvent
@@ -34,12 +35,11 @@ fun EditUsernameScreen(viewModel: EditUsernameViewModel) {
                 fontWeight = FontWeight.Bold
             )
             CustomOutlinedTextField(
+                textFieldType = TextFieldType.USERNAME,
                 value = textUsername,
                 onValueChange = {
                     viewModel.onEvent(TextUsernameChanged(it))
                 },
-                label = stringResource(id = R.string.general_username_label),
-                keyboardType = KeyboardType.Text
             )
             Text(
                 modifier = Modifier

--- a/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotIdle.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/forgotPassScreen/ForgotIdle.kt
@@ -3,7 +3,6 @@ package com.dodo.flashcards.presentation.forgotPassScreen
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -12,13 +11,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.dodo.flashcards.R
 import com.dodo.flashcards.architecture.EventReceiver
 import com.dodo.flashcards.presentation.common.CustomOutlinedTextField
-import com.dodo.flashcards.presentation.registerScreen.RegisterScreenViewEvent
+import com.dodo.flashcards.presentation.common.TextFieldType
 import com.dodo.flashcards.presentation.theme.Typography
 
 @Composable
@@ -44,12 +42,11 @@ fun ForgotIdle(
         text = stringResource(id = R.string.forgot_pass_prompt)
     )
     CustomOutlinedTextField(
+        textFieldType = TextFieldType.EMAIL,
         value = textEmail,
         onValueChange = {
             eventReceiver.onEvent(ForgotPassViewEvent.TextChangedEmail(it))
         },
-        label = stringResource(id = R.string.general_email_label),
-        keyboardType = KeyboardType.Text
     )
     Button(
         modifier = Modifier.defaultMinSize(

--- a/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreen.kt
@@ -21,6 +21,7 @@ import com.dodo.flashcards.presentation.common.ScreenBackground
 import com.dodo.flashcards.presentation.loginScreen.LoginScreenViewEvent.*
 import com.dodo.flashcards.presentation.common.CustomOutlinedTextField
 import com.dodo.flashcards.presentation.common.PasswordTextField
+import com.dodo.flashcards.presentation.common.TextFieldType
 import com.dodo.flashcards.presentation.theme.Typography
 
 @Composable
@@ -45,10 +46,9 @@ fun LoginScreen(viewModel: LoginScreenViewModel) {
                 fontStyle = FontStyle.Italic
             )
             CustomOutlinedTextField(
+                textFieldType = TextFieldType.USERNAME,
                 value = textEmail,
                 onValueChange = { viewModel.onEvent(TextEmailChanged(it)) },
-                label = stringResource(R.string.general_email_label),
-                keyboardType = KeyboardType.Email,
             )
             PasswordTextField(
                 value = textPass,

--- a/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterIdle.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterIdle.kt
@@ -18,6 +18,9 @@ import com.dodo.flashcards.R
 import com.dodo.flashcards.architecture.EventReceiver
 import com.dodo.flashcards.presentation.common.CustomOutlinedTextField
 import com.dodo.flashcards.presentation.common.PasswordTextField
+import com.dodo.flashcards.presentation.common.TextFieldType
+import com.dodo.flashcards.presentation.registerScreen.RegisterScreenViewEvent.*
+import com.dodo.flashcards.presentation.loginScreen.LoginScreenViewEvent
 import com.dodo.flashcards.presentation.theme.Typography
 
 @Composable
@@ -37,12 +40,9 @@ fun RegisterIdle(
         fontWeight = FontWeight.Bold
     )
     CustomOutlinedTextField(
+        textFieldType = TextFieldType.USERNAME,
         value = textUsername,
-        onValueChange = {
-            eventReceiver.onEvent(RegisterScreenViewEvent.TextUsernameChanged(changedTo = it))
-        },
-        label = stringResource(id = R.string.general_username_label),
-        keyboardType = KeyboardType.Text
+        onValueChange = { eventReceiver.onEvent(TextUsernameChanged(it)) }
     )
     Text(
         modifier = Modifier
@@ -54,13 +54,9 @@ fun RegisterIdle(
         text = stringResource(R.string.register_register_username_subtext)
     )
     CustomOutlinedTextField(
+        textFieldType = TextFieldType.EMAIL,
         value = textEmail,
-        onValueChange = {
-            eventReceiver.onEvent(RegisterScreenViewEvent.TextEmailChanged(changedTo = it))
-        },
-        label = stringResource(R.string.general_email_label),
-        placeholderText = stringResource(R.string.general_placeholder_email_text),
-        keyboardType = KeyboardType.Email
+        onValueChange = { eventReceiver.onEvent(TextEmailChanged(it)) }
     )
     Text(
         modifier =
@@ -98,7 +94,7 @@ fun RegisterIdle(
         modifier = Modifier.defaultMinSize(
             minWidth = dimensionResource(id = R.dimen.min_width_button)
         ),
-     //   enabled = buttonsEnabled,
+        //   enabled = buttonsEnabled,
         onClick = {
             eventReceiver.onEventDebounced(RegisterScreenViewEvent.ClickedRegister)
         }


### PR DESCRIPTION
refactor: Update custom text fields to use a type for code reuse | #33 #47 #49

* Add an enum class TextFieldType, to abstract some of the repetition of creating username and email text fields.