### PR TITLE
feat: Add additional error handling | #52

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassModels.kt
@@ -13,10 +13,12 @@ sealed interface EditPassViewEvent : ViewEvent {
 }
 
 data class EditPassViewState(
-    val confirmButtonEnabled: Boolean,
-    val hasSuccessfullySet: Boolean,
-    val passHiddenOld: Boolean,
-    val passHiddenNew: Boolean,
-    val textPassNew: String,
-    val textPassOld: String
+    val clickEventsEnabled: Boolean = true,
+    val hasSuccessfullySet: Boolean = false,
+    val errorMessagePassNew: String? = null,
+    val errorMessagePassOld: String? = null,
+    val passHiddenNew: Boolean = false,
+    val passHiddenOld: Boolean = false,
+    val textPassNew: String = String(),
+    val textPassOld: String = String()
 ) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassScreen.kt
@@ -63,6 +63,8 @@ fun EditPassScreen(viewModel: EditPassViewModel) {
                     fontWeight = FontWeight.Bold
                 )
                 PasswordTextField(
+                    enabled = clickEventsEnabled,
+                    errorMessage = errorMessagePassOld,
                     value = textPassOld,
                     onValueChange = {
                         viewModel.onEvent(
@@ -87,6 +89,8 @@ fun EditPassScreen(viewModel: EditPassViewModel) {
                     text = "For your security, enter your previous password."
                 )
                 PasswordTextField(
+                    enabled = clickEventsEnabled,
+                    errorMessage = errorMessagePassNew,
                     value = textPassNew,
                     onValueChange = {
                         viewModel.onEvent(
@@ -112,7 +116,7 @@ fun EditPassScreen(viewModel: EditPassViewModel) {
                 )
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Button(
-                        enabled = confirmButtonEnabled,
+                        enabled = clickEventsEnabled,
                         onClick = {
                             viewModel.onEventDebounced(ClickedConfirm)
                         }) {


### PR DESCRIPTION
feat: Add additional error handling | #52

* This commit adds error handling for invalid input on the edit password screen.
* This commit concludes commits for this sprint which will add error handling features and therefore the following issues included here as closed.

Closes #53 
Closes #52 
Closes #33 
Closes #9 
Closes #8 
Closes #5 