### PR TITLE
feat: Add user input handling to edit username | #52

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameModels.kt
@@ -10,7 +10,8 @@ sealed interface EditUsernameViewEvent : ViewEvent {
 }
 
 data class EditUsernameViewState(
-    val confirmButtonEnabled: Boolean,
-    val hasSuccessfullySet: Boolean,
+    val buttonsEnabled: Boolean = true,
+    val errorMessage: String? = null,
+    val hasSuccessfullySet: Boolean = false,
     val textUsername: String,
 ) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editUsername/EditUsernameScreen.kt
@@ -35,6 +35,8 @@ fun EditUsernameScreen(viewModel: EditUsernameViewModel) {
                 fontWeight = FontWeight.Bold
             )
             CustomOutlinedTextField(
+                enabled = buttonsEnabled,
+                errorMessage = errorMessage,
                 textFieldType = TextFieldType.USERNAME,
                 value = textUsername,
                 onValueChange = {
@@ -66,7 +68,7 @@ fun EditUsernameScreen(viewModel: EditUsernameViewModel) {
                     modifier = Modifier.defaultMinSize(
                         minWidth = dimensionResource(id = R.dimen.min_width_button)
                     ),
-                    //   enabled = buttonsEnabled,
+                    enabled = buttonsEnabled,
                     onClick = {
                         viewModel.onEventDebounced(ClickedConfirm)
                     }


### PR DESCRIPTION
feat: Add user input handling to edit username | #52

* Adds an error message when the username is the same or when the new username would be invalid.

Closes #52