### PR TITLE
fix: Fix why Android allowed edit password to an invalid password.

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/editProfileScreen/subscreens/editPass/EditPassViewModel.kt
@@ -40,13 +40,13 @@ class EditPassViewModel @Inject constructor(
 
     private fun onClickedConfirm() {
         viewModelScope.launch(Dispatchers.IO) {
-            var errorMessagePassNew: String? = null
             var errorMessagePassOld: String? = null
             lastPushedState?.apply {
-                copy(clickEventsEnabled = false).push()
                 if (!userUtils.isValidPassword(textPassNew)) {
-                    errorMessagePassNew = "This is not a valid password."
+                    copy(errorMessagePassNew = "This is not a valid password.").push()
+                    return@launch
                 }
+                copy(clickEventsEnabled = false).push()
                 updatePasswordUseCase(
                     oldPassword = textPassOld,
                     newPassword = textPassNew


### PR DESCRIPTION
fix: Fix why Android allowed edit password to an invalid password.

* Add a single line to address overlooked bug which resulted in receiving -3 on the last sprint.
* If invalid, return rather than progressing.