### PR TITLE
feat: Stub out View Tags screen | #71

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/presentation/MainNavHost.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainNavHost.kt
@@ -16,11 +16,13 @@ import com.dodo.flashcards.presentation.editProfileScreen.subscreens.editUsernam
 import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassScreen
 import com.dodo.flashcards.presentation.forgotPassScreen.ForgotPassViewModel
 import com.dodo.flashcards.presentation.loginScreen.LoginScreen
-import com.dodo.flashcards.presentation.loginScreen.LoginScreenViewModel
+import com.dodo.flashcards.presentation.loginScreen.LoginViewModel
 import com.dodo.flashcards.presentation.registerScreen.RegisterScreen
-import com.dodo.flashcards.presentation.registerScreen.RegisterScreenViewModel
+import com.dodo.flashcards.presentation.registerScreen.RegisterViewModel
+import com.dodo.flashcards.presentation.viewTagsScreen.ViewTagsScreen
+import com.dodo.flashcards.presentation.viewTagsScreen.ViewTagsViewModel
 import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreen
-import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewModel
+import com.dodo.flashcards.presentation.welcomeScreen.WelcomeViewModel
 import com.dodo.flashcards.util.Screen.*
 import com.google.accompanist.navigation.animation.AnimatedNavHost
 import com.google.accompanist.navigation.animation.composable
@@ -62,17 +64,22 @@ fun MainNavHost(
             })
         }
         composable(route = Login.route) {
-            LoginScreen(viewModel = hiltViewModel<LoginScreenViewModel>().apply {
+            LoginScreen(viewModel = hiltViewModel<LoginViewModel>().apply {
                 attachRouter(router)
             })
         }
         composable(route = Register.route) {
-            RegisterScreen(viewModel = hiltViewModel<RegisterScreenViewModel>().apply {
+            RegisterScreen(viewModel = hiltViewModel<RegisterViewModel>().apply {
                 attachRouter(router)
             })
         }
         composable(route = Welcome.route) {
-            WelcomeScreen(viewModel = hiltViewModel<WelcomeScreenViewModel>().apply {
+            WelcomeScreen(viewModel = hiltViewModel<WelcomeViewModel>().apply {
+                attachRouter(router)
+            })
+        }
+        composable(route = ViewTags.route) {
+            ViewTagsScreen(viewModel = hiltViewModel<ViewTagsViewModel>().apply {
                 attachRouter(router)
             })
         }

--- a/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginScreen.kt
@@ -24,7 +24,7 @@ import com.dodo.flashcards.presentation.common.TextFieldType
 import com.dodo.flashcards.presentation.theme.Typography
 
 @Composable
-fun LoginScreen(viewModel: LoginScreenViewModel) {
+fun LoginScreen(viewModel: LoginViewModel) {
     ScreenBackground {
         viewModel.viewState.collectAsState().value?.apply {
             Text(

--- a/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/loginScreen/LoginViewModel.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
-class LoginScreenViewModel @Inject constructor(
+class LoginViewModel @Inject constructor(
     private val loginUserUseCase: LoginUserUseCase
 ) : BaseRoutingViewModel<LoginScreenViewState, LoginScreenViewEvent, MainDestination>() {
 

--- a/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterScreen.kt
@@ -1,34 +1,14 @@
 package com.dodo.flashcards.presentation.registerScreen
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import com.dodo.flashcards.R
-import com.dodo.flashcards.presentation.registerScreen.RegisterScreenViewEvent.*
-import com.dodo.flashcards.presentation.common.CustomOutlinedTextField
-import com.dodo.flashcards.presentation.common.PasswordTextField
 import com.dodo.flashcards.presentation.common.ScreenBackground
 import com.dodo.flashcards.presentation.registerScreen.RegisterScreenViewState.*
-import com.dodo.flashcards.presentation.theme.DarkColors
-import com.dodo.flashcards.presentation.theme.Typography
 
 
 @Composable
-fun RegisterScreen(viewModel: RegisterScreenViewModel) {
+fun RegisterScreen(viewModel: RegisterViewModel) {
     ScreenBackground {
         viewModel.viewState.collectAsState().value?.apply {
             when (this) {

--- a/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/registerScreen/RegisterViewModel.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
-class RegisterScreenViewModel @Inject constructor(
+class RegisterViewModel @Inject constructor(
     private val registerUserUseCase: RegisterUserUseCase,
     private val userUtils: UserUtils
 ) : BaseRoutingViewModel<RegisterScreenViewState, RegisterScreenViewEvent, MainDestination>() {

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsModels.kt
@@ -1,0 +1,13 @@
+package com.dodo.flashcards.presentation.viewTagsScreen
+
+import com.dodo.flashcards.architecture.ViewEvent
+import com.dodo.flashcards.architecture.ViewState
+
+sealed interface ViewTagsViewEvent : ViewEvent {
+
+}
+
+data class ViewTagsViewState(
+    val selectedIndices: Set<Int>,
+    val tags: List<String>,
+) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsScreen.kt
@@ -1,0 +1,8 @@
+package com.dodo.flashcards.presentation.viewTagsScreen
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun ViewTagsScreen(viewModel: ViewTagsViewModel) {
+
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsViewModel.kt
@@ -1,0 +1,18 @@
+package com.dodo.flashcards.presentation.viewTagsScreen
+
+import com.dodo.flashcards.architecture.BaseRoutingViewModel
+import com.dodo.flashcards.domain.usecases.authentication.GetUserUseCase
+import com.dodo.flashcards.domain.usecases.authentication.LogoutUserUseCase
+import com.dodo.flashcards.presentation.MainDestination
+import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewEvent
+import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ViewTagsViewModel @Inject constructor(
+) : BaseRoutingViewModel<ViewTagsViewState, ViewTagsViewEvent, MainDestination>() {
+    override fun onEvent(event: ViewTagsViewEvent) {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
@@ -1,15 +1,10 @@
 package com.dodo.flashcards.presentation.welcomeScreen
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -17,12 +12,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.dodo.flashcards.R
 import com.dodo.flashcards.presentation.common.ScreenBackground
-import com.dodo.flashcards.presentation.theme.DarkColors
 import com.dodo.flashcards.presentation.theme.Typography
 import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewEvent.*
 
 @Composable
-fun WelcomeScreen(viewModel: WelcomeScreenViewModel) {
+fun WelcomeScreen(viewModel: WelcomeViewModel) {
     ScreenBackground {
         viewModel.viewState.collectAsState().value?.apply {
             Text(

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class WelcomeScreenViewModel @Inject constructor(
+class WelcomeViewModel @Inject constructor(
     private val getUserUseCase: GetUserUseCase,
     private val logoutUserUseCase: LogoutUserUseCase,
 ) : BaseRoutingViewModel<WelcomeScreenViewState, WelcomeScreenViewEvent, MainDestination>() {

--- a/app/src/main/java/com/dodo/flashcards/util/Screen.kt
+++ b/app/src/main/java/com/dodo/flashcards/util/Screen.kt
@@ -12,6 +12,7 @@ sealed class Screen(val route: String) {
     object ForgotPass : Screen("ForgotPass")
     object Login : Screen("Login")
     object Register : Screen("Register")
+    object ViewTags : Screen("ViewTags")
     object Welcome : Screen("Welcome")
 
     fun withArgs(args: Array<Pair<String, String>>? = null): String {


### PR DESCRIPTION
* feat: Stub out View Tags screen | #71
* Stubs out standard MVVM architecture for the screen which is associated with viewing tags.
* Renames some ViewModels to remove reference to screen.