### PR TITLE
feat: Stub out View Cards screen | #72

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/domain/models/flashcard/Flashcard.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/models/flashcard/Flashcard.kt
@@ -1,0 +1,6 @@
+package com.dodo.flashcards.domain.models.flashcard
+
+interface Flashcard {
+	val front: String
+	val back: String
+}

--- a/app/src/main/java/com/dodo/flashcards/domain/models/flashcard/FlashcardImpl.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/models/flashcard/FlashcardImpl.kt
@@ -1,0 +1,6 @@
+package com.dodo.flashcards.domain.models.flashcard
+
+data class FlashcardImpl(
+	override val front: String,
+	override val back: String,
+) : Flashcard

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsModels.kt
@@ -1,0 +1,15 @@
+package com.dodo.flashcards.presentation.viewCardsScreen
+
+import com.dodo.flashcards.architecture.ViewEvent
+import com.dodo.flashcards.architecture.ViewState
+import com.dodo.flashcards.domain.models.flashcard.Flashcard
+
+sealed interface ViewCardsViewEvent : ViewEvent {
+	object SwipedAnyDirection : ViewCardsViewEvent
+}
+
+data class ViewCardsViewState(
+	val currentIndex: Int,
+	val currentCard: Flashcard,
+	val nextCard: Flashcard
+) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsScreen.kt
@@ -1,0 +1,9 @@
+package com.dodo.flashcards.presentation.viewCardsScreen
+
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.runtime.Composable
+
+@Composable
+fun ViewCardsScreen(viewModel: ViewCardsViewModel) {
+
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsViewModel.kt
@@ -1,0 +1,41 @@
+package com.dodo.flashcards.presentation.viewCardsScreen
+
+import com.dodo.flashcards.architecture.BaseRoutingViewModel
+import com.dodo.flashcards.domain.models.flashcard.FlashcardImpl
+import com.dodo.flashcards.domain.models.flashcard.Flashcard
+import com.dodo.flashcards.presentation.MainDestination
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import com.dodo.flashcards.presentation.viewCardsScreen.ViewCardsViewEvent.SwipedAnyDirection
+
+@HiltViewModel
+class ViewCardsViewModel @Inject constructor(
+) : BaseRoutingViewModel<ViewCardsViewState, ViewCardsViewEvent, MainDestination>() {
+
+	//placeholder list construction
+	val cards: List<Flashcard> = listOf<Flashcard>(
+		FlashcardImpl("This is my front", "This is my back"),
+		FlashcardImpl("This is my other front", "This is my other back")
+	)
+
+	init {
+		pushState(
+			ViewCardsViewState(
+				currentIndex = 0,
+				currentCard = cards[0],
+				nextCard = cards[1]
+			)
+		)
+	}
+
+	override fun onEvent(event: ViewCardsViewEvent) {
+		when (event) {
+			is SwipedAnyDirection -> onSwiped()
+		}
+	}
+
+	private fun onSwiped() {
+		TODO("Not yet implemented")
+	}
+
+}


### PR DESCRIPTION
* Stubs out standard MVVM architecture for the screen that will ultimately provide a one-at-a-time card view and allow for swiping.
* Currently provides scaffolding for one type of swipe event.
* Stubbed out Flashcard interface, as well as a single bare bones implementation.