### PR TITLE
refactor: Move flashcard mocking to a flashcard repository impl | #72

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/data/repository/FlashcardRepositoryImpl.kt
+++ b/app/src/main/java/com/dodo/flashcards/data/repository/FlashcardRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.dodo.flashcards.data.repository
+
+import com.dodo.flashcards.domain.models.Flashcard
+import com.dodo.flashcards.domain.models.FlashcardRepository
+import com.dodo.flashcards.util.Response
+
+class FlashcardRepositoryImpl : FlashcardRepository {
+    override suspend fun getFlashcards(tags: List<String>): Response<List<Flashcard>> {
+        // TODO, this is mocked, do something later
+        return Response.Success(
+            listOf(
+                TempFlashcard(
+                    front = "This is my front",
+                    back = "This is my back"
+                ),
+                TempFlashcard(
+                    front = "This is my front 1",
+                    back = "This is my back 1"
+                ),
+            )
+        )
+    }
+
+    @Deprecated("Delete this later, only used while mocking.")
+    private data class TempFlashcard(
+        override val front: String,
+        override val back: String
+    ) : Flashcard
+}

--- a/app/src/main/java/com/dodo/flashcards/di/AppModule.kt
+++ b/app/src/main/java/com/dodo/flashcards/di/AppModule.kt
@@ -1,7 +1,9 @@
 package com.dodo.flashcards.di
 
 import com.dodo.flashcards.data.repository.AuthRepositoryImpl
+import com.dodo.flashcards.data.repository.FlashcardRepositoryImpl
 import com.dodo.flashcards.domain.models.AuthRepository
+import com.dodo.flashcards.domain.models.FlashcardRepository
 import com.dodo.flashcards.util.UserUtils
 import com.google.firebase.auth.FirebaseAuth
 import dagger.Module
@@ -21,6 +23,9 @@ object AppModule {
     fun provideAuthRepository(
         firebaseAuth: FirebaseAuth
     ): AuthRepository = AuthRepositoryImpl(firebaseAuth)
+
+    @Provides
+    fun provideFlashcardRepository(): FlashcardRepository = FlashcardRepositoryImpl()
 
     @Provides
     fun provideUserUtils(): UserUtils = UserUtils()

--- a/app/src/main/java/com/dodo/flashcards/domain/models/Flashcard.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/models/Flashcard.kt
@@ -1,4 +1,4 @@
-package com.dodo.flashcards.domain.models.flashcard
+package com.dodo.flashcards.domain.models
 
 interface Flashcard {
 	val front: String

--- a/app/src/main/java/com/dodo/flashcards/domain/models/FlashcardRepository.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/models/FlashcardRepository.kt
@@ -1,0 +1,7 @@
+package com.dodo.flashcards.domain.models
+
+import com.dodo.flashcards.util.Response
+
+interface FlashcardRepository {
+    suspend fun getFlashcards(tags: List<String>): Response<List<Flashcard>>
+}

--- a/app/src/main/java/com/dodo/flashcards/domain/models/flashcard/FlashcardImpl.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/models/flashcard/FlashcardImpl.kt
@@ -1,6 +1,0 @@
-package com.dodo.flashcards.domain.models.flashcard
-
-data class FlashcardImpl(
-	override val front: String,
-	override val back: String,
-) : Flashcard

--- a/app/src/main/java/com/dodo/flashcards/domain/usecases/flashcards/GetFlashcardsUseCase.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/usecases/flashcards/GetFlashcardsUseCase.kt
@@ -1,0 +1,14 @@
+package com.dodo.flashcards.domain.usecases.flashcards
+
+import com.dodo.flashcards.domain.models.Flashcard
+import com.dodo.flashcards.domain.models.FlashcardRepository
+import com.dodo.flashcards.util.Response
+import javax.inject.Inject
+
+class GetFlashcardsUseCase @Inject constructor(
+    private val flashcardRepository: FlashcardRepository
+) {
+    suspend operator fun invoke(tags: List<String>): Response<List<Flashcard>> {
+        return flashcardRepository.getFlashcards(tags)
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsModels.kt
@@ -2,7 +2,7 @@ package com.dodo.flashcards.presentation.viewCardsScreen
 
 import com.dodo.flashcards.architecture.ViewEvent
 import com.dodo.flashcards.architecture.ViewState
-import com.dodo.flashcards.domain.models.flashcard.Flashcard
+import com.dodo.flashcards.domain.models.Flashcard
 
 sealed interface ViewCardsViewEvent : ViewEvent {
 	object SwipedAnyDirection : ViewCardsViewEvent
@@ -10,7 +10,7 @@ sealed interface ViewCardsViewEvent : ViewEvent {
 }
 
 data class ViewCardsViewState(
-	val currentIndex: Int,
-	val currentCard: Flashcard,
-	val nextCard: Flashcard
+    val currentIndex: Int,
+    val currentCard: Flashcard,
+    val nextCard: Flashcard
 ) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsViewModel.kt
@@ -1,48 +1,53 @@
 package com.dodo.flashcards.presentation.viewCardsScreen
 
+import androidx.lifecycle.viewModelScope
 import com.dodo.flashcards.architecture.BaseRoutingViewModel
-import com.dodo.flashcards.domain.models.flashcard.FlashcardImpl
-import com.dodo.flashcards.domain.models.flashcard.Flashcard
+import com.dodo.flashcards.domain.usecases.flashcards.GetFlashcardsUseCase
 import com.dodo.flashcards.presentation.MainDestination
-import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
-import com.dodo.flashcards.presentation.viewCardsScreen.ViewCardsViewEvent.SwipedAnyDirection
 import com.dodo.flashcards.presentation.viewCardsScreen.ViewCardsViewEvent.Flip
+import com.dodo.flashcards.presentation.viewCardsScreen.ViewCardsViewEvent.SwipedAnyDirection
+import com.dodo.flashcards.util.doOnError
+import com.dodo.flashcards.util.doOnSuccess
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
 class ViewCardsViewModel @Inject constructor(
+    getFlashcardsUseCase: GetFlashcardsUseCase
 ) : BaseRoutingViewModel<ViewCardsViewState, ViewCardsViewEvent, MainDestination>() {
 
-	//placeholder list construction
-	val cards: List<Flashcard> = listOf<Flashcard>(
-		FlashcardImpl("This is my front", "This is my back"),
-		FlashcardImpl("This is my other front", "This is my other back")
-	)
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            getFlashcardsUseCase(listOf())
+                .doOnSuccess {
+                    ViewCardsViewState(
+                        currentIndex = 0,
+                        currentCard = data[0],
+                        nextCard = data[1]
+                    ).push()
+                }
+                .doOnError {
+                    // Todo
+                }
+        }
+    }
 
-	init {
-		pushState(
-			ViewCardsViewState(
-				currentIndex = 0,
-				currentCard = cards[0],
-				nextCard = cards[1]
-			)
-		)
-	}
+    override fun onEvent(event: ViewCardsViewEvent) {
+        when (event) {
+            is SwipedAnyDirection -> onSwiped()
+            is Flip -> onFlip()
+        }
+    }
 
-	override fun onEvent(event: ViewCardsViewEvent) {
-		when (event) {
-			is SwipedAnyDirection -> onSwiped()
-			is Flip -> onFlip()
-		}
-	}
+    private fun onSwiped() {
+        TODO("Not yet implemented")
+    }
 
-	private fun onSwiped() {
-		TODO("Not yet implemented")
-	}
-
-	private fun onFlip() {
-		TODO("Not yet implemented")
-	}
+    private fun onFlip() {
+        TODO("Not yet implemented")
+    }
 
 
 }


### PR DESCRIPTION
refactor: Move flashcard mocking to a flashcard repository impl | #72

* Move mocking into FlashcardRepositoryImpl, so that only very little needs to be changed in the future.