### PR TITLE
feat: Stub out navigation to view tags | #71

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/data/repository/FlashcardRepositoryImpl.kt
+++ b/app/src/main/java/com/dodo/flashcards/data/repository/FlashcardRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.dodo.flashcards.data.repository
 
 import com.dodo.flashcards.domain.models.Flashcard
 import com.dodo.flashcards.domain.models.FlashcardRepository
+import com.dodo.flashcards.domain.models.Tag
 import com.dodo.flashcards.util.Response
 
 class FlashcardRepositoryImpl : FlashcardRepository {
@@ -21,9 +22,24 @@ class FlashcardRepositoryImpl : FlashcardRepository {
         )
     }
 
+    override suspend fun getTags(): Response<List<Tag>> {
+        return Response.Success(
+            listOf(
+                TempTag("Tag 1"),
+                TempTag("Tag 2"),
+                TempTag("Tag 3"),
+            )
+        )
+    }
+
     @Deprecated("Delete this later, only used while mocking.")
     private data class TempFlashcard(
         override val front: String,
         override val back: String
     ) : Flashcard
+
+    @Deprecated("Delete this later, only used while mocking.")
+    private data class TempTag(
+        override val value: String
+    ) : Tag
 }

--- a/app/src/main/java/com/dodo/flashcards/domain/models/FlashcardRepository.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/models/FlashcardRepository.kt
@@ -4,4 +4,5 @@ import com.dodo.flashcards.util.Response
 
 interface FlashcardRepository {
     suspend fun getFlashcards(tags: List<String>): Response<List<Flashcard>>
+    suspend fun getTags(): Response<List<Tag>>
 }

--- a/app/src/main/java/com/dodo/flashcards/domain/models/Tag.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/models/Tag.kt
@@ -1,0 +1,5 @@
+package com.dodo.flashcards.domain.models
+
+interface Tag {
+    val value: String
+}

--- a/app/src/main/java/com/dodo/flashcards/domain/usecases/flashcards/GetTagsUseCase.kt
+++ b/app/src/main/java/com/dodo/flashcards/domain/usecases/flashcards/GetTagsUseCase.kt
@@ -1,0 +1,14 @@
+package com.dodo.flashcards.domain.usecases.flashcards
+
+import com.dodo.flashcards.domain.models.FlashcardRepository
+import com.dodo.flashcards.domain.models.Tag
+import com.dodo.flashcards.util.Response
+import javax.inject.Inject
+
+class GetTagsUseCase @Inject constructor(
+    private val flashcardRepository: FlashcardRepository
+) {
+    suspend operator fun invoke(): Response<List<Tag>> {
+        return flashcardRepository.getTags()
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainActivity.kt
@@ -50,6 +50,7 @@ class MainActivity : ComponentActivity(), Router<MainDestination> {
             is NavigateRegister -> navigateRegister()
             is NavigateUp -> navigateUp()
             is NavigateWelcome -> navigateWelcome()
+            is NavigateViewTags -> navigateViewTags()
         }
     }
 
@@ -108,5 +109,9 @@ class MainActivity : ComponentActivity(), Router<MainDestination> {
                 inclusive = true
             }
         }
+    }
+
+    private fun navigateViewTags() {
+        navController.navigate(route = ViewTags.route)
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/MainModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/MainModels.kt
@@ -22,4 +22,5 @@ sealed interface MainDestination : Destination {
     object NavigateRegister : MainDestination
     object NavigateUp : MainDestination
     object NavigateWelcome : MainDestination
+    object NavigateViewTags : MainDestination
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsModels.kt
@@ -2,6 +2,7 @@ package com.dodo.flashcards.presentation.viewTagsScreen
 
 import com.dodo.flashcards.architecture.ViewEvent
 import com.dodo.flashcards.architecture.ViewState
+import com.dodo.flashcards.domain.models.Tag
 
 sealed interface ViewTagsViewEvent : ViewEvent {
 
@@ -9,5 +10,5 @@ sealed interface ViewTagsViewEvent : ViewEvent {
 
 data class ViewTagsViewState(
     val selectedIndices: Set<Int>,
-    val tags: List<String>,
+    val tags: List<Tag>,
 ) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsScreen.kt
@@ -1,8 +1,36 @@
 package com.dodo.flashcards.presentation.viewTagsScreen
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Button
+import androidx.compose.material.Checkbox
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import com.dodo.flashcards.presentation.common.ScreenBackground
 
 @Composable
 fun ViewTagsScreen(viewModel: ViewTagsViewModel) {
-
+    ScreenBackground {
+        viewModel.viewState.collectAsState().value?.apply {
+            Column {
+                tags.forEachIndexed { index, tag ->
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(tag.value)
+                        Checkbox(
+                            checked = selectedIndices.contains(index),
+                            onCheckedChange = {}
+                        )
+                    }
+                }
+                Button(
+                    onClick = {}
+                ) {
+                    Text("View Flashcards")
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsViewModel.kt
@@ -1,17 +1,35 @@
 package com.dodo.flashcards.presentation.viewTagsScreen
 
+import androidx.lifecycle.viewModelScope
 import com.dodo.flashcards.architecture.BaseRoutingViewModel
 import com.dodo.flashcards.domain.usecases.authentication.GetUserUseCase
 import com.dodo.flashcards.domain.usecases.authentication.LogoutUserUseCase
+import com.dodo.flashcards.domain.usecases.flashcards.GetTagsUseCase
 import com.dodo.flashcards.presentation.MainDestination
 import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewEvent
 import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewState
+import com.dodo.flashcards.util.doOnError
+import com.dodo.flashcards.util.doOnSuccess
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ViewTagsViewModel @Inject constructor(
+    getTagsUseCase: GetTagsUseCase
 ) : BaseRoutingViewModel<ViewTagsViewState, ViewTagsViewEvent, MainDestination>() {
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            getTagsUseCase()
+                .doOnSuccess {
+                    ViewTagsViewState(setOf(), data).push()
+                }
+                .doOnError { }
+        }
+    }
+
     override fun onEvent(event: ViewTagsViewEvent) {
         TODO("Not yet implemented")
     }

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreen.kt
@@ -44,10 +44,20 @@ fun WelcomeScreen(viewModel: WelcomeViewModel) {
                         minWidth = dimensionResource(id = R.dimen.min_width_button)
                     ),
                     onClick = {
+                        viewModel.onEventDebounced(ClickedViewTags)
+                    }) {
+                    Text(text = "View Tags")
+                }
+                OutlinedButton(
+                    modifier = Modifier.defaultMinSize(
+                        minWidth = dimensionResource(id = R.dimen.min_width_button)
+                    ),
+                    onClick = {
                         viewModel.onEventDebounced(ClickedLogout)
                     }) {
                     Text(text = stringResource(R.string.welcome_logout_button))
                 }
+
             }
         }
     }

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreenModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeScreenModels.kt
@@ -6,6 +6,7 @@ import com.dodo.flashcards.architecture.ViewState
 sealed interface WelcomeScreenViewEvent : ViewEvent {
     object ClickedEditProfile : WelcomeScreenViewEvent
     object ClickedLogout : WelcomeScreenViewEvent
+    object ClickedViewTags : WelcomeScreenViewEvent
 }
 
 data class WelcomeScreenViewState(val username: String?) : ViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/welcomeScreen/WelcomeViewModel.kt
@@ -6,11 +6,9 @@ import com.dodo.flashcards.domain.usecases.authentication.GetUserUseCase
 import com.dodo.flashcards.domain.usecases.authentication.LogoutUserUseCase
 import com.dodo.flashcards.presentation.MainDestination
 import com.dodo.flashcards.presentation.MainDestination.*
-import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewEvent.ClickedEditProfile
-import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewEvent.ClickedLogout
+import com.dodo.flashcards.presentation.welcomeScreen.WelcomeScreenViewEvent.*
 import com.dodo.flashcards.util.doOnError
 import com.dodo.flashcards.util.doOnSuccess
-import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -39,6 +37,7 @@ class WelcomeViewModel @Inject constructor(
         when (event) {
             is ClickedEditProfile -> onClickedEditProfile()
             is ClickedLogout -> onClickedLogout()
+            is ClickedViewTags -> onClickedViewTags()
         }
     }
 
@@ -51,5 +50,9 @@ class WelcomeViewModel @Inject constructor(
             logoutUserUseCase()
             routeTo(NavigateLogin)
         }
+    }
+
+    private fun onClickedViewTags() {
+        routeTo(NavigateViewTags)
     }
 }


### PR DESCRIPTION
feat: Stub out navigation to view tags | #71

* This commit stubs out the basic crude navigation from the welcome screen to the screen which will display all tags.
* The tags are returned by a mock response without function and without any intentional styling.