### PR TITLE
feat: Implement tags received from Firestore | #71

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth-ktx:21.0.8'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.1'
 
+    // Firestore
+    implementation 'com.google.firebase:firebase-firestore-ktx:24.4.0'
+
     // Retrofit
     // https://github.com/square/retrofitokhttp3
     // https://github.com/square/okhttp

--- a/app/src/main/java/com/dodo/flashcards/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/dodo/flashcards/data/repository/AuthRepositoryImpl.kt
@@ -35,7 +35,6 @@ class AuthRepositoryImpl @Inject constructor(private val auth: FirebaseAuth) : A
         username: String
     ): Response<User> {
         return try {
-
             auth.createUserWithEmailAndPassword(email, password).await().user!!.let { newUser ->
                 newUser.updateProfile(
                     UserProfileChangeRequest.Builder().setDisplayName(username).build()

--- a/app/src/main/java/com/dodo/flashcards/di/AppModule.kt
+++ b/app/src/main/java/com/dodo/flashcards/di/AppModule.kt
@@ -6,6 +6,9 @@ import com.dodo.flashcards.domain.models.AuthRepository
 import com.dodo.flashcards.domain.models.FlashcardRepository
 import com.dodo.flashcards.util.UserUtils
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -25,8 +28,14 @@ object AppModule {
     ): AuthRepository = AuthRepositoryImpl(firebaseAuth)
 
     @Provides
-    fun provideFlashcardRepository(): FlashcardRepository = FlashcardRepositoryImpl()
+    fun provideFlashcardRepository(
+        db: FirebaseFirestore
+    ): FlashcardRepository = FlashcardRepositoryImpl(db)
 
     @Provides
     fun provideUserUtils(): UserUtils = UserUtils()
+
+    @Singleton
+    @Provides
+    fun provideDb(): FirebaseFirestore = Firebase.firestore
 }


### PR DESCRIPTION
* feat: Implement tags received from Firestore | #71
* This commit removes the placeholder mocking of tags and instead reads directly from Firestore all tags in the tags collection.