### PR TITLE
feat: Add forward / previous temp buttons with func | #72

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsModels.kt
@@ -6,16 +6,23 @@ import com.dodo.flashcards.domain.models.Flashcard
 
 
 sealed interface ViewCardsViewEvent : ViewEvent {
-    object SwipedAnyDirection : ViewCardsViewEvent
     object ClickedCard : ViewCardsViewEvent
+    object ClickedReturnPreviousCard : ViewCardsViewEvent
+    object SwipedCard : ViewCardsViewEvent
 }
 
 sealed interface ViewCardsViewState : ViewState {
+    /**
+     * @param hasPreviousCard Informs View whether to show a button which allows
+     * user to view the last card.
+     * @param nextCardFront Informs View whether to show a card behind the current card
+     * and what its content should be.
+     */
     data class CardsLoaded(
         val currentCardBack: String,
         val currentCardFront: String,
-        val currentCardIndex: Int,
         val currentCardIsFlipped: Boolean,
+        val hasPreviousCard: Boolean,
         val nextCardFront: String?
     ) : ViewCardsViewState
     object CardsLoading : ViewCardsViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsScreen.kt
@@ -17,8 +17,8 @@ fun ViewCardsScreen(viewModel: ViewCardsViewModel) {
                 is CardsLoaded -> CardsLoaded(
                     currentCardBack,
                     currentCardFront,
-                    currentCardIndex,
                     currentCardIsFlipped,
+                    hasPreviousCard,
                     nextCardFront,
                     viewModel
                 )

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/subscreen/CardsLoaded.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/subscreen/CardsLoaded.kt
@@ -1,6 +1,10 @@
 package com.dodo.flashcards.presentation.viewCardsScreen.subscreen
 
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Button
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.dodo.flashcards.architecture.EventReceiver
@@ -12,11 +16,21 @@ import com.dodo.flashcards.presentation.viewCardsScreen.ViewCardsViewEvent
 fun CardsLoaded(
     currentCardBack: String,
     currentCardFront: String,
-    currentCardIndex: Int,
     currentCardIsFlipped: Boolean,
+    hasPreviousCard: Boolean,
     nextCardFront: String?,
     eventReceiver: EventReceiver<ViewCardsViewEvent>
 ) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        if (hasPreviousCard) {
+            Button(onClick = { eventReceiver.onEvent(ClickedReturnPreviousCard) }) {
+                Text("Previous")
+            }
+        }
+        Button(onClick = { eventReceiver.onEvent(SwipedCard) }) {
+            Text("Next")
+        }
+    }
     FlippableFlashCard(
         isCardFlipped = currentCardIsFlipped,
         onCardClicked = { eventReceiver.onEvent(ClickedCard) },
@@ -24,4 +38,5 @@ fun CardsLoaded(
         backContent = currentCardBack,
         modifier = Modifier.fillMaxSize()
     )
+
 }


### PR DESCRIPTION
feat: Add forward / previous temp buttons with func | #72
* Adds two temporary buttons and basic error handling for them which can be later repurposed into more final view events.