### PR TITLE
feat: Clean up errors associated with View Tags & View Cards | #72

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/presentation/common/ScreenBackground.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/common/ScreenBackground.kt
@@ -19,17 +19,21 @@ import com.dodo.flashcards.presentation.theme.DarkColors
 @Composable
 fun ScreenBackground(
     scrollEnabled: Boolean = true,
-    content: @Composable () -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
 ) {
     val surfaceColor = MaterialTheme.colors.surface
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(surfaceColor)
-            .padding(16.dp).apply {
-                if (scrollEnabled)
-                    verticalScroll(rememberScrollState(), enabled = scrollEnabled)
-            },
+            .run {
+                if (scrollEnabled) {
+                    verticalScroll(rememberScrollState())
+                } else {
+                    this
+                }
+            }
+            .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically)
     ) {

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/DummyCard.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/DummyCard.kt
@@ -1,10 +1,7 @@
 package com.dodo.flashcards.presentation.viewCardsScreen
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Undo
@@ -13,6 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.dodo.flashcards.presentation.theme.Typography
 
 @Composable
 fun DummyCard(
@@ -25,19 +23,30 @@ fun DummyCard(
         modifier = modifier,
         backgroundColor = backgroundColor,
         elevation = 0.dp,
-        border = BorderStroke(4.dp, MaterialTheme.colors.secondary)
+        border = BorderStroke(1.dp, MaterialTheme.colors.secondary.copy(alpha = 0.5f))
     ) {
         Box(
             modifier = Modifier.fillMaxSize(),
         ) {
-            Row(modifier = Modifier.padding(16.dp)) {
-                IconButton(onClick = {  }) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = { }) {
                     Icon(
                         imageVector = Icons.Default.Undo,
                         tint = MaterialTheme.colors.secondary,
                         contentDescription = null
                     )
                 }
+                Text(
+                    text = "QUESTION",
+                    style = Typography.subtitle2,
+                    color = MaterialTheme.colors.secondary,
+                )
             }
             Text(
                 modifier = Modifier.align(Alignment.Center),

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/FlippableFlashCard.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/FlippableFlashCard.kt
@@ -7,10 +7,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -22,6 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import com.dodo.flashcards.presentation.common.commonModifiers.flipCard
+import com.dodo.flashcards.presentation.theme.Typography
 
 @Composable
 fun FlippableFlashCard(
@@ -53,12 +51,18 @@ fun FlippableFlashCard(
          */
         backgroundColor = backgroundColor,
         elevation = 0.dp,
-        border = BorderStroke(4.dp, MaterialTheme.colors.secondary)
+        border = BorderStroke(1.dp, MaterialTheme.colors.secondary.copy(alpha = 0.5f))
     ) {
         Box(
             modifier = Modifier.fillMaxSize()
         ) {
-            Row(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 IconButton(onClick = { onClickedPrevious() }) {
                     Icon(
                         imageVector = Icons.Default.Undo,
@@ -66,6 +70,11 @@ fun FlippableFlashCard(
                         contentDescription = null
                     )
                 }
+                Text(
+                    text = if (isCardFlipped) "ANSWER" else "QUESTION",
+                    style = Typography.subtitle2,
+                    color = MaterialTheme.colors.secondary,
+                )
             }
             Text(
                 text = if (isCardFlipped) backContent else frontContent,

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsModels.kt
@@ -8,18 +8,13 @@ import java.util.*
 
 sealed interface ViewCardsViewEvent : ViewEvent {
     object ClickedCard : ViewCardsViewEvent
+    object ClickedNavigateUp : ViewCardsViewEvent
     object ClickedReturnPreviousCard : ViewCardsViewEvent
     object SwipedCard : ViewCardsViewEvent
     object SwipedCardReset : ViewCardsViewEvent
 }
 
 sealed interface ViewCardsViewState : ViewState {
-    /**
-     * @param hasPreviousCard Informs View whether to show a button which allows
-     * user to view the last card.
-     * @param nextCardFront Informs View whether to show a card behind the current card
-     * and what its content should be.
-     */
     data class CardsLoaded(
         val currentCard: Flashcard,
         val nextCard: Flashcard,

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsScreen.kt
@@ -10,16 +10,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.dodo.flashcards.presentation.common.ScreenBackground
 import com.dodo.flashcards.presentation.viewCardsScreen.ViewCardsViewState.*
+import com.dodo.flashcards.presentation.viewCardsScreen.subscreen.CardsLoadError
 import com.dodo.flashcards.presentation.viewCardsScreen.subscreen.CardsLoaded
+import com.dodo.flashcards.util.Screen
 
 
 @Composable
 fun ViewCardsScreen(viewModel: ViewCardsViewModel) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Top,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+    ScreenBackground(scrollEnabled = false) {
         viewModel.viewState.collectAsState().value?.apply {
             when (this) {
                 is CardsLoading -> CircularProgressIndicator()
@@ -29,8 +27,7 @@ fun ViewCardsScreen(viewModel: ViewCardsViewModel) {
                     isFlipped,
                     viewModel
                 )
-                is CardsLoadError -> { // todo
-                }
+                is CardsLoadError -> CardsLoadError(viewModel)
             }
         }
     }

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/subscreen/CardsLoadError.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/subscreen/CardsLoadError.kt
@@ -1,0 +1,18 @@
+package com.dodo.flashcards.presentation.viewCardsScreen.subscreen
+
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import com.dodo.flashcards.architecture.EventReceiver
+import com.dodo.flashcards.presentation.viewCardsScreen.ViewCardsViewEvent
+import com.dodo.flashcards.presentation.viewCardsScreen.ViewCardsViewEvent.*
+import com.dodo.flashcards.presentation.viewCardsScreen.ViewCardsViewState
+import com.dodo.flashcards.presentation.viewTagsScreen.ViewTagsViewEvent
+
+@Composable
+fun CardsLoadError(eventReceiver: EventReceiver<ViewCardsViewEvent>) {
+    Text("There are not enough cards associated with these tags to quiz on.")
+    TextButton(onClick = { eventReceiver.onEventDebounced(ClickedNavigateUp) }) {
+        Text("Return")
+    }
+}

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsModels.kt
@@ -14,6 +14,8 @@ sealed interface ViewTagsViewState : ViewState {
     object LoadErrorTags : ViewTagsViewState
     object LoadingTags : ViewTagsViewState
     data class LoadedTags(
+        val continueButtonEnabled: Boolean,
+        val errorMessage: String? = null,
         val selectedIndices: Set<Int>,
         val tags: List<Tag>
     ) : ViewTagsViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsViewDelegate.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsViewDelegate.kt
@@ -15,7 +15,13 @@ fun ViewTagsScreen(viewModel: ViewTagsViewModel) {
             when (this) {
                 is LoadErrorTags -> LoadErrorTags()
                 is LoadingTags -> LoadingTags()
-                is LoadedTags -> LoadedTags(tags, selectedIndices, viewModel)
+                is LoadedTags -> LoadedTags(
+                    continueButtonEnabled,
+                    errorMessage,
+                    tags,
+                    selectedIndices,
+                    viewModel
+                )
             }
         }
     }

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/ViewTagsViewModel.kt
@@ -26,6 +26,8 @@ class ViewTagsViewModel @Inject constructor(
             getTagsUseCase()
                 .doOnSuccess {
                     LoadedTags(
+                        continueButtonEnabled = false,
+                        errorMessage = "Must select at least one tag",
                         selectedIndices = setOf(),
                         tags = data
                     ).push()
@@ -60,9 +62,18 @@ class ViewTagsViewModel @Inject constructor(
     private fun onToggledTag(event: ToggledTag) {
         val index = event.index
         (lastPushedState as? LoadedTags)?.run {
-            copy(selectedIndices = selectedIndices.toMutableSet().let {
+            val newSelectedIndices = selectedIndices.toMutableSet().let {
                 if (it.contains(index)) it - index else it + index
-            })
+            }
+            copy(
+                continueButtonEnabled = newSelectedIndices.size in 1..10,
+                errorMessage = when {
+                    newSelectedIndices.isEmpty() -> "Must select at least one tag"
+                    newSelectedIndices.size > 10 -> "May only select 10 tags"
+                    else -> null
+                },
+                selectedIndices = newSelectedIndices
+            )
         }?.push()
     }
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/subscreen/LoadedTags.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewTagsScreen/subscreen/LoadedTags.kt
@@ -1,19 +1,13 @@
 package com.dodo.flashcards.presentation.viewTagsScreen.subscreen
 
-import androidx.compose.foundation.gestures.rememberScrollableState
-import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.dodo.flashcards.R
 import com.dodo.flashcards.architecture.EventReceiver
 import com.dodo.flashcards.domain.models.Tag
 import com.dodo.flashcards.presentation.theme.Typography
@@ -22,47 +16,56 @@ import com.dodo.flashcards.presentation.viewTagsScreen.ViewTagsViewEvent.*
 
 @Composable
 fun LoadedTags(
+    continueButtonEnabled: Boolean,
+    errorMessage: String?,
     tags: List<Tag>,
     selectedIndices: Set<Int>,
     eventReceiver: EventReceiver<ViewTagsViewEvent>
 ) {
-    Column(
-        modifier = Modifier.verticalScroll(state = rememberScrollState()),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top)
-    ) {
-        Text(
-            text = "Select Tags",
-            style = Typography.h6,
-            color = MaterialTheme.colors.onBackground,
-            textAlign = TextAlign.Center
-        )
-        tags.forEachIndexed { index, tag ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Start,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Checkbox(
-                    checked = selectedIndices.contains(index),
-                    onCheckedChange = {
-                        eventReceiver.onEvent(ToggledTag(index))
-                    }
-                )
-                Text(tag.value)
-            }
-        }
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Button(
-                onClick = {
-                    eventReceiver.onEventDebounced(ClickedViewCards)
+    Text(
+        text = "Select Tags",
+        style = Typography.h6,
+        color = MaterialTheme.colors.onBackground,
+        textAlign = TextAlign.Center
+    )
+    tags.forEachIndexed { index, tag ->
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Start,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Checkbox(
+                checked = selectedIndices.contains(index),
+                onCheckedChange = {
+                    eventReceiver.onEvent(ToggledTag(index))
                 }
-            ) {
-                Text("View Flashcards")
-            }
-            TextButton(onClick = { eventReceiver.onEventDebounced(ClickedNavigateUp) }) {
-                Text("Return")
-            }
+            )
+            Text(tag.value)
+        }
+    }
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Button(
+            onClick = {
+                eventReceiver.onEventDebounced(ClickedViewCards)
+            },
+            enabled = continueButtonEnabled,
+        ) {
+            Text("View Flashcards")
+        }
+        errorMessage?.let {
+            Text(
+                modifier =
+                Modifier
+                    .padding(horizontal = 16.dp)
+                    .fillMaxWidth(0.9f),
+                style = Typography.subtitle2,
+                color = Color(139, 0, 0),
+                textAlign = TextAlign.Center,
+                text = it
+            )
+        }
+        TextButton(onClick = { eventReceiver.onEventDebounced(ClickedNavigateUp) }) {
+            Text("Return")
         }
     }
 }


### PR DESCRIPTION
feat: Clean up errors associated with View Tags & View Cards

* Prevent navigating to View Cards when selected tags are less than 1 or greater than 10.
* Redirect user to an error state if it turns out that selected tags produce less than 2 cards.
* Fix a bug introduced where Screen background was not functional to add a vertical scroll.