### PR TITLE
Prevent multiple click bug | #97

### DIFF
--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/FlashCard.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/FlashCard.kt
@@ -12,22 +12,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.dodo.flashcards.presentation.common.commonModifiers.reversed
 import com.dodo.flashcards.presentation.theme.Typography
 import com.dodo.flashcards.presentation.viewCardsScreen.modifiers.flip.FlippableCardState
 import com.dodo.flashcards.presentation.viewCardsScreen.modifiers.flip.flippableCard
 import com.dodo.flashcards.presentation.viewCardsScreen.modifiers.swipe.SwipeableCardState
-import com.dodo.flashcards.presentation.viewCardsScreen.modifiers.swipeableCard
+import com.dodo.flashcards.presentation.viewCardsScreen.modifiers.swipe.swipeableCard
 
 @Composable
 fun FlashCard(
     swipeableCardState: SwipeableCardState,
-    flippableCardState: FlippableCardState,
+    flippableCardState: FlippableCardState? = null,
     colorText: Color = MaterialTheme.colors.onBackground,
     enabled: Boolean = true,
-    isDummy: Boolean = false,
     isCardFlipped: Boolean = false,
     onClickedCard: () -> Unit = {},
     onClickedPrevious: () -> Unit = {},
@@ -36,16 +34,20 @@ fun FlashCard(
 ) {
     Box(
         modifier = Modifier
-            .flippableCard(
-                enabled = enabled,
-                flippableCardState = flippableCardState,
-                onClick = onClickedCard,
-            )
+            .run {
+                if (enabled && flippableCardState != null) {
+                    flippableCard(
+                        flippableCardState = flippableCardState,
+                        onClick = onClickedCard,
+                    )
+                } else {
+                    this
+                }
+            }
             .swipeableCard(
                 enabled = enabled,
                 swipeableCardState = swipeableCardState,
                 onSwipedCard = onSwipedCard,
-                isDummy = isDummy
             )
     ) {
         Row(

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsModels.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsModels.kt
@@ -10,13 +10,11 @@ sealed interface ViewCardsViewEvent : ViewEvent {
     object ClickedReturnPreviousCard : ViewCardsViewEvent
     object SwipedCard : ViewCardsViewEvent
     object SwipedCardReset : ViewCardsViewEvent
-    object ClickedPreviousReset : ViewCardsViewEvent
 }
 
 sealed interface ViewCardsViewState : ViewState {
     data class CardsLoaded(
         val currentCard: Flashcard,
-        val dummyCard: Flashcard?,
         val nextCard: Flashcard,
         val isFlipped: Boolean = false,
     ) : ViewCardsViewState

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsScreen.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsScreen.kt
@@ -24,7 +24,6 @@ fun ViewCardsScreen(viewModel: ViewCardsViewModel) {
                     is CardsLoaded -> CardsLoaded(
                         currentCard = currentCard,
                         nextCard = nextCard,
-                        previousCard = dummyCard,
                         isFlipped = isFlipped,
                         eventReceiver = viewModel
                     )

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsViewModel.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/ViewCardsViewModel.kt
@@ -58,7 +58,6 @@ class ViewCardsViewModel @Inject constructor(
             is ClickedCard -> onClickedCard()
             is ClickedNavigateUp -> onClickedNavigateUp()
             is ClickedReturnPreviousCard -> onClickedReturnPreviousCard()
-            is ClickedPreviousReset -> onClickedPreviousReset()
             is SwipedCard -> onSwipedCard()
             is SwipedCardReset -> onSwipedCardReset()
         }
@@ -79,19 +78,8 @@ class ViewCardsViewModel @Inject constructor(
     private fun onClickedReturnPreviousCard() {
         (lastPushedState as? CardsLoaded)?.run {
             wholeDeck.run {
-                currentCardIndex = if (currentCardIndex == 0) (size - 1)
-                else getPreviousIndex(currentCardIndex)
-                copy(dummyCard = get(currentCardIndex)).push()
-            }
-        }
-    }
-
-    private fun onClickedPreviousReset() {
-        (lastPushedState as? CardsLoaded)?.run {
-            wholeDeck.run {
-
+                currentCardIndex = getPreviousIndex(currentCardIndex)
                 copy(
-                    dummyCard = null,
                     isFlipped = false,
                     currentCard = get(currentCardIndex),
                     nextCard = get(getNextIndex(currentCardIndex))
@@ -128,7 +116,6 @@ class ViewCardsViewModel @Inject constructor(
             CardsLoaded(
                 currentCard = get(currentCardIndex),
                 nextCard = get(getNextIndex(currentCardIndex)),
-                dummyCard = null
             )
         }.push()
     }

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/modifiers/flip/CardFlipModifiers.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/modifiers/flip/CardFlipModifiers.kt
@@ -26,28 +26,23 @@ fun Modifier.flippableCard(
     strokeWidth: Dp = 2.dp,
     colorStroke: Color = MaterialTheme.colors.secondary,
     shape: RoundedCornerShape = RoundedCornerShape(16.dp),
-    enabled: Boolean,
     onClick: () -> Unit = {},
 ) = composed {
-    when (enabled) {
-        false -> Modifier
-        else -> clickable(
-            interactionSource = remember { MutableInteractionSource() },
-            indication = null
-        ) {
-            flippableCardState.animateFlip(onClick)
-        }
-            .graphicsLayer {
-                rotationY = flippableCardState.rotationY
-                cameraDistance = 150f
-            }
-            .border(
-                width = strokeWidth,
-                shape = shape,
-                color = colorStroke.copy(
-                    alpha = flippableCardState.strokeAlpha
-                )
-            )
+    clickable(
+        interactionSource = remember { MutableInteractionSource() },
+        indication = null
+    ) {
+        flippableCardState.animateFlip(onClick)
     }
-
+        .graphicsLayer {
+            rotationY = flippableCardState.rotationY
+            cameraDistance = 150f
+        }
+        .border(
+            width = strokeWidth,
+            shape = shape,
+            color = colorStroke.copy(
+                alpha = flippableCardState.rotationFraction
+            )
+        )
 }

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/modifiers/swipe/CardSwipeModifiers.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/modifiers/swipe/CardSwipeModifiers.kt
@@ -1,6 +1,5 @@
-package com.dodo.flashcards.presentation.viewCardsScreen.modifiers
+package com.dodo.flashcards.presentation.viewCardsScreen.modifiers.swipe
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -10,7 +9,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.draw.shadow
@@ -21,7 +19,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.dodo.flashcards.presentation.viewCardsScreen.modifiers.swipe.SwipeableCardState
 import com.dodo.flashcards.presentation.viewCardsScreen.modifiers.swipe.SwipeableCardState.Companion.INITIAL_POSITION
 import kotlin.math.abs
 
@@ -46,7 +43,6 @@ fun Modifier.swipeableCard(
     colorBackground: Color = MaterialTheme.colors.primaryVariant,
     shape: Shape = RoundedCornerShape(16.dp),
     elevationShadow: Dp = 8.dp,
-    isDummy: Boolean = false,
     strokeWidth: Dp = 2.dp,
     rotationDegreesMaximum: Int = 20,
     sizeFractionMinimumDisabledCard: Float = 0.9f,
@@ -63,9 +59,13 @@ fun Modifier.swipeableCard(
                     if (offsetX < 0) it * -1 else it
                 },
                 onDrag = {
-                    dragByAnimate(it.x, it.y)
+                    println("Drag releasable event: $it")
+                    if (it != Offset.Unspecified) {
+                        dragByAnimate(it.x, it.y)
+                    }
                 },
                 onDragReleased = {
+                    println("Drag releasable event: $offsetX")
                     when {
                         abs(offsetX) > swipeAcceptanceMin -> {
                             acceptSwipeByAnimate(toLeft = offsetX < INITIAL_POSITION)
@@ -79,11 +79,9 @@ fun Modifier.swipeableCard(
             )
         } else {
             scale(
-                scale =
-                if (!isDummy) convertHorizontalOffsetToNewRange(sizeFractionMinimumDisabledCard..1f) else 1f
+                scale = convertHorizontalOffsetToNewRange(sizeFractionMinimumDisabledCard..1f)
             ).graphicsLayer {
-                translationY =
-                    if (!isDummy) -(convertHorizontalOffsetToNewRange(-80f..0f)) else 1f
+                //  translationY = -(convertHorizontalOffsetToNewRange(-80f..0f))
             }
         }
             .border(
@@ -93,7 +91,7 @@ fun Modifier.swipeableCard(
                 ),
                 shape = shape
             )
-            .shadow(shape = shape, elevation = if (isDummy) 0.dp else elevationShadow)
+            .shadow(shape = shape, elevation = elevationShadow)
             .clip(shape)
             .background(colorBackground)
             .fillMaxSize()
@@ -116,6 +114,7 @@ private fun Modifier.dragReleasable(
             onDragEnd = { onDragReleased() }
         )
     }.graphicsLayer {
+        println("yo here $translationX x and y is $translationY")
         this.translationX = translationX
         this.translationY = translationY
         this.rotationZ = rotationZ

--- a/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/subscreen/CardsLoaded.kt
+++ b/app/src/main/java/com/dodo/flashcards/presentation/viewCardsScreen/subscreen/CardsLoaded.kt
@@ -17,6 +17,7 @@ import com.dodo.flashcards.presentation.viewCardsScreen.ViewCardsViewEvent
 import com.dodo.flashcards.presentation.viewCardsScreen.ViewCardsViewEvent.*
 import com.dodo.flashcards.presentation.viewCardsScreen.modifiers.flip.rememberFlippableCardState
 import com.dodo.flashcards.presentation.viewCardsScreen.modifiers.swipe.rememberSwipeableCardState
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -24,7 +25,6 @@ import kotlinx.coroutines.launch
 fun CardsLoaded(
     currentCard: Flashcard?,
     nextCard: Flashcard?,
-    previousCard: Flashcard?,
     isFlipped: Boolean,
     eventReceiver: EventReceiver<ViewCardsViewEvent>,
 ) {
@@ -41,9 +41,8 @@ fun CardsLoaded(
             FlashCard(
                 enabled = false,
                 swipeableCardState = swipeableCardState,
-                flippableCardState = flippableCardState,
                 text = it.front,
-                isDummy = false,
+                //   isDummy = false,
             )
         }
         currentCard?.let {
@@ -53,6 +52,7 @@ fun CardsLoaded(
                     eventReceiver.onEvent(ClickedCard)
                 },
                 onClickedPrevious = {
+                    flippableCardState.resetRotationBySnap()
                     eventReceiver.onEvent(ClickedReturnPreviousCard)
                 },
                 onSwipedCard = {
@@ -61,17 +61,7 @@ fun CardsLoaded(
                 },
                 swipeableCardState = swipeableCardState,
                 flippableCardState = flippableCardState,
-                isDummy = false,
                 text = if (isFlipped) it.back else it.front
-            )
-        }
-        previousCard?.let {
-            FlashCard(
-                swipeableCardState = swipeableCardState,
-                flippableCardState = flippableCardState,
-                enabled = false,
-                isDummy = true,
-                text = it.front
             )
         }
         SideEffect {
@@ -79,14 +69,6 @@ fun CardsLoaded(
                 swipeableCardState.resetPositionBySnap()
                 eventReceiver.onEvent(SwipedCardReset)
             }
-            if (previousCard != null) {
-                flippableCardState.resetRotationBySnap()
-                eventReceiver.onEvent(ClickedPreviousReset)
-            }
         }
     }
 }
-
-
-
-


### PR DESCRIPTION
* Prevent multiple click bug | #97
* This commit fixes a bug which existed when rapidly clicking to flip a card.  The bug resulted in a crash due to an offset being detected as unspecified.